### PR TITLE
reorders authorino nav items

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,6 @@ nav:
     - 'Authorino Operator': authorino-operator/README.md
     - 'Getting Started': authorino/docs/getting-started.md
     - 'Architecture': authorino/docs/architecture.md
-    - 'Reference': authorino/docs/features.md
     - 'How-to':
       - 'Hello World': authorino/docs/user-guides/hello-world.md
       - 'Authentication with Kubernetes tokens (TokenReview API)': authorino/docs/user-guides/kubernetes-tokenreview.md
@@ -116,6 +115,7 @@ nav:
       - 'Reducing the operational space: sharding, noise and multi-tenancy': authorino/docs/user-guides/sharding.md
       - 'Caching': authorino/docs/user-guides/caching.md
       - 'Observability': authorino/docs/user-guides/observability.md
+    - 'Reference': authorino/docs/features.md
     - "Developer's Guide": authorino/docs/contributing.md
   - 'Limitador':
     - 'Overview': limitador/README.md


### PR DESCRIPTION
Reorders authorino nav items, for consistency with other sections. First `How-to`, then `Reference`.