### PR TITLE
Removes kuadrant-addon-walkthrough link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,7 +137,6 @@ nav:
       - 'Setup and use TLSPpolicy': multicluster-gateway-controller/docs/tls-policy.md
       - 'Setup and use DNSPolicy': multicluster-gateway-controller/docs/dns-policy.md
       - multicluster-gateway-controller/docs/how-to/ocm-control-plane-walkthrough.md
-      - multicluster-gateway-controller/docs/how-to/kuadrant-addon-walkthrough.md
       - multicluster-gateway-controller/docs/how-to/managedZone.md
       - multicluster-gateway-controller/docs/how-to/ratelimiting-shared-redis.md
       - multicluster-gateway-controller/docs/how-to/submariner-poc-hub-gateway-walkthrough.md


### PR DESCRIPTION
As the walkthrough was removed [here](https://github.com/Kuadrant/multicluster-gateway-controller/pull/453).