### PR TITLE
Metrics federation doc removed

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,6 @@ nav:
   - 'How-to Guides':
     - 'Multicluster Gateway Controller':
       - 'Multicluster Gateways Walkthrough': multicluster-gateway-controller/docs/how-to/multicluster-gateways-walkthrough.md
-      - 'Metrics Federation': multicluster-gateway-controller/docs/how-to/metrics-federation.md
       - 'Metrics Walkthrough': multicluster-gateway-controller/docs/how-to/metrics-walkthrough.md
     - 'Rate Limiting':
       - kuadrant-operator/doc/user-guides/simple-rl-for-app-developers.md


### PR DESCRIPTION
`Metrics Federation` will be removed [https://github.com/Kuadrant/multicluster-gateway-controller/pull/598](https://github.com/Kuadrant/multicluster-gateway-controller/pull/598)
Should be merged after that one?