### PR TITLE
AuthPolicy v2 docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,28 +76,25 @@ nav:
       - 'Defining and Distributing Multicluster Gateways with OCM': multicluster-gateway-controller/docs/gateways/define-and-place-a-gateway.md
       - 'Gateway Deletion': multicluster-gateway-controller/docs/gateways/gateway-deletion.md
     - 'DNSPolicy':
-      - 'DNSPolicy Quickstart': multicluster-gateway-controller/docs/dnspolicy/dnspolicy-quickstart.md
-      - 'DNSPolicy Reference': multicluster-gateway-controller/docs/dnspolicy/dns-policy.md
+      - 'Quickstart': multicluster-gateway-controller/docs/dnspolicy/dnspolicy-quickstart.md
+      - 'Reference': multicluster-gateway-controller/docs/dnspolicy/dns-policy.md
       - 'DNS Health Checks': multicluster-gateway-controller/docs/dnspolicy/dns-health-checks.md
       - 'DNS Providers': multicluster-gateway-controller/docs/dnspolicy/dns-provider.md
       - 'ManagedZone Reference': multicluster-gateway-controller/docs/dnspolicy/managed-zone.md
     - 'TLSPolicy':
-      - 'TLSPolicy Reference': multicluster-gateway-controller/docs/tlspolicy/tls-policy.md
+      - 'Reference': multicluster-gateway-controller/docs/tlspolicy/tls-policy.md
     - 'AuthPolicy':
-      - 'AuthPolicy Reference': kuadrant-operator/doc/proposals/authpolicy-crd.md
+      - 'Overview': kuadrant-operator/doc/auth.md
+      - 'Reference': kuadrant-operator/doc/reference/authpolicy.md
     - 'RateLimitPolicy':
-      - 'RateLimitPolicy Overview': kuadrant-operator/doc/rate-limiting.md
-      - 'RateLimitPolicy (v1beta2)': kuadrant-operator/doc/ratelimitpolicy-reference.md
+      - 'Overview': kuadrant-operator/doc/rate-limiting.md
+      - 'Reference': kuadrant-operator/doc/reference/ratelimitpolicy.md
   - 'How-to Guides':
     - 'Multicluster Gateway Controller':
       - 'Multicluster Gateways Walkthrough': multicluster-gateway-controller/docs/how-to/multicluster-gateways-walkthrough.md
       - 'Metrics Walkthrough': multicluster-gateway-controller/docs/how-to/metrics-walkthrough.md
-    - 'Rate Limiting':
-      - 'RateLimitPolicy for Application Developers': multicluster-gateway-controller/docs/how-to/simple-ratelimitpolicy-for-app-developers.md
-      - kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
-      - kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
-    - 'Authorino':
-      - 'Hello World': authorino/docs/user-guides/hello-world.md
+    - 'Authentication & Authorization':
+      - 'AuthPolicy for Application Developers and Platform Engineers': kuadrant-operator/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
       - 'Authentication with Kubernetes tokens (TokenReview API)': authorino/docs/user-guides/kubernetes-tokenreview.md
       - 'Authentication with API keys': authorino/docs/user-guides/api-key-authentication.md
       - 'Authentication with X.509 certificates and mTLS': authorino/docs/user-guides/mtls-authentication.md
@@ -112,27 +109,34 @@ nav:
       - 'OpenID Connect UserInfo': authorino/docs/user-guides/oidc-user-info.md
       - 'Resource-level authorization with User-Managed Access (UMA) resource registry': authorino/docs/user-guides/resource-level-authorization-uma.md
       - 'Simple pattern-matching authorization policies': authorino/docs/user-guides/json-pattern-matching-authorization.md
-      - 'OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Authorino and Keycloak': authorino/docs/user-guides/oidc-rbac.md
+      - 'OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak': authorino/docs/user-guides/oidc-rbac.md
       - 'Open Policy Agent (OPA) Rego policies': authorino/docs/user-guides/opa-authorization.md
       - 'Kubernetes RBAC for service authorization (SubjectAccessReview API)': authorino/docs/user-guides/kubernetes-subjectaccessreview.md
       - 'Authorization with Keycloak Authorization Services': authorino/docs/user-guides/keycloak-authorization-services.md
       - 'Integration with Authzed/SpiceDB': authorino/docs/user-guides/authzed.md
       - 'Injecting data in the request': authorino/docs/user-guides/injecting-data.md
-      - 'Authenticated rate limiting (with Envoy Dynamic Metadata)': authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+      - 'Emitting Envoy Dynamic Metadata': authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
       - 'Redirecting to a login page': authorino/docs/user-guides/deny-with-redirect-to-login.md
-      - 'Mixing Envoy built-in filter for auth and Authorino': authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
-      - 'Host override via context extension': authorino/docs/user-guides/host-override.md
-      - 'Using Authorino as ValidatingWebhook service': authorino/docs/user-guides/validating-webhook.md
-      - 'Reducing the operational space: sharding, noise and multi-tenancy': authorino/docs/user-guides/sharding.md
+      - 'Reusing Envoy built-in authentication filter result': authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
+      - 'Setting up Kuadrant authorization service as a Validating Webhook': authorino/docs/user-guides/validating-webhook.md
       - 'Caching': authorino/docs/user-guides/caching.md
       - 'Observability': authorino/docs/user-guides/observability.md
+    - 'Rate Limiting':
+      - 'RateLimitPolicy for Application Developers': multicluster-gateway-controller/docs/how-to/simple-ratelimitpolicy-for-app-developers.md
+      - 'RateLimitPolicy for Platform Engineers': kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
+      - kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
   - 'Experimental':
     - 'Kuadrant and Skupper Gateway Resiliency': multicluster-gateway-controller/docs/experimental/skupper-poc-2-gateways-resiliency-walkthrough.md
     - 'Kuadrant and Submariner Gateway Resiliency': multicluster-gateway-controller/docs/experimental/submariner-poc-2-gateways-resiliency-walkthrough.md
   - 'Proposals':
+    - 'Request For Comments (RFC)':
+      - 'RFC 0001: RateLimitPolicy API "v2"': architecture/rfcs/0001-rlp-v2.md
+      - 'RFC 0002: Well-known Attributes': architecture/rfcs/0002-well-known-attributes.md
+      - 'RFC 0003: DNSPolicy': architecture/rfcs/0003-dns-policy.md
+      - 'RFC 0004: Policy Status': architecture/rfcs/0004-rlp-status.md
     - 'Multicluster Gateway Controller':
-      - 'Proposal: Multiple DNS Provider Support': multicluster-gateway-controller/docs/proposals/multiple-dns-provider-support.md
-      - 'Proposal: Aggregation of Status Conditions': multicluster-gateway-controller/docs/proposals/status-aggregation.md
+      - 'Multiple DNS Provider Support': multicluster-gateway-controller/docs/proposals/multiple-dns-provider-support.md
+      - 'Aggregation of Status Conditions': multicluster-gateway-controller/docs/proposals/status-aggregation.md
   - 'Components':
     - 'Kuadrant Operator':
       - 'Overview': kuadrant-operator/README.md
@@ -142,8 +146,12 @@ nav:
       - 'Overview': authorino/README.md
       - 'Authorino Operator': authorino-operator/README.md
       - 'Getting Started': authorino/docs/getting-started.md
+      - 'Hello World': authorino/docs/user-guides/hello-world.md
       - 'Architecture': authorino/docs/architecture.md
       - 'Reference': authorino/docs/features.md
+      - 'Advanced features':
+        - 'Host override via context extension': authorino/docs/user-guides/host-override.md
+        - 'Reducing the operational space: sharding, noise and multi-tenancy': authorino/docs/user-guides/sharding.md
       - "Developer's Guide": authorino/docs/contributing.md
     - 'Limitador':
       - 'Overview': limitador/README.md
@@ -163,4 +171,3 @@ nav:
       - 'Overview': multicluster-gateway-controller/README.md
       - 'Contribution':
         - 'Debugging with VSCode': multicluster-gateway-controller/docs/contribution/vscode-debugging.md
-


### PR DESCRIPTION
- New auth policy overview and API reference
- Removed redundant `<X>Policy ` prefix from submenu titles
- Re-added section "RFCs"
- Authorino non-Kuadrant user guides moved to component-specific section