### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ And dependencies
 ## Running Locally
 `mkdocs serve`
 
+The docs should then be available locally from http://127.0.0.1:8000/
+
 **Note:** `mkdocs` will automatically clone component repositories as configured via `mkdocs.yml`.
 
 ## Building

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ export MGC_BRANCH=release-0.1
 Run the following:
 
 ```bash
-curl https://raw.githubusercontent.com/kuadrant/multicluster-gateway-controller/${MGC_BRANCH}/hack/quickstart-setup.sh | bash
+curl "https://raw.githubusercontent.com/kuadrant/multicluster-gateway-controller/${MGC_BRANCH}/hack/quickstart-setup.sh" | bash
 ```
 
 ### What's Next


### PR DESCRIPTION
**Summary**
* Fixed issue with copying/pasting the getting started curl command when using zsh (see [slack thread](https://kubernetes.slack.com/archives/C05J0D0V525/p1698836281419569) for context)
* Updated README to reference access URL for running docs locally