### PR TITLE
WIP add craft RLP

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ plugins:
       keep_docs_dir: true
       nav_repos:
         - name: kuadrant-operator
-          import_url: 'https://github.com/kuadrant/kuadrant-operator?edit_uri=/blob/main/&branch=main'
+          import_url: 'https://github.com/Boomatang/kuadrant-operator?edit_uri=/blob/docs/craft_policy/&branch=docs/craft_policy' # Chnages is only for review propose, merge version will not have this change
           imports:
             - /README.md
             - /doc/*
@@ -93,6 +93,7 @@ nav:
       - 'Reference': kuadrant-operator/doc/reference/authpolicy.md
     - 'RateLimitPolicy':
       - 'Overview': kuadrant-operator/doc/rate-limiting.md
+      - 'Crafting A Policy': kuadrant-operator/doc/craft/ratelimitpolicy.md
       - 'Reference': kuadrant-operator/doc/reference/ratelimitpolicy.md
   - 'How-to Guides':
     - 'Multicluster Gateway Controller':


### PR DESCRIPTION
Add section for crafting RateLimitPolicy

## Verification 

* run `mkdocs serve`
* navigate to http://127.0.0.1:8000/kuadrant-operator/doc/craft/ratelimitpolicy
* Expected: 
  * all links reference page on site
  * layout and formatting looks correct