### PR TITLE
Activate md_in_html extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.superfences
   - attr_list
+  - md_in_html
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
Enables [`md_in_html`](https://python-markdown.github.io/extensions/md_in_html/) Python-Markdown extension.

Provided an attribute `markdown="1"` is added to the HTML blocks that contain markdown content inside, that content will render properly with this extension. E.g.:

**Before**

<img width="1358" alt="Screenshot 2023-11-08 at 18 10 37" src="https://github.com/Kuadrant/docs.kuadrant.io/assets/1842261/99b6e0d4-5aa8-4bc2-889c-15e96bf84129">

<br/>
<br/>

**After**

<img width="1358" alt="Screenshot 2023-11-08 at 18 10 42" src="https://github.com/Kuadrant/docs.kuadrant.io/assets/1842261/e75e269b-ddb0-4c20-923e-7f3b6a236faf">

<br/>
<br/>

By also editing the original Markdown file https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/kubernetes-tokenreview.md as such:

```diff
diff --git a/docs/user-guides/kubernetes-tokenreview.md b/docs/user-guides/kubernetes-tokenreview.md
index 718d80a1..a70caa9f 100644
--- a/docs/user-guides/kubernetes-tokenreview.md
+++ b/docs/user-guides/kubernetes-tokenreview.md
@@ -2,7 +2,7 @@
 
 Validate Kubernetes Service Account tokens to authenticate requests to your protected hosts.
 
-<details>
+<details markdown="1">
   <summary>
     <strong>Authorino capabilities featured in this guide:</strong>
     <ul>
```

The new attribute added to the HTML block has no side-effect o how the file renders in GitHub.