### PR TITLE
Freeze mgc branch to release

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,7 @@ plugins:
             - /README.md
             - /doc/*
         - name: multicluster-gateway-controller
-          import_url: 'https://github.com/kuadrant/multicluster-gateway-controller?edit_uri=/blob/main/&branch=main'
+          import_url: 'https://github.com/kuadrant/multicluster-gateway-controller?edit_uri=/blob/release-0.1/&branch=release-0.1'
           imports:
             - /README.md
             - /docs/*


### PR DESCRIPTION
Freezing only MGC for now, as I think some docs improvements are in progress on other components.