### PR TITLE
Add temp_dir/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+temp_dir/
 site
 __pycache__/
 .idea/


### PR DESCRIPTION
`mkdocs serve` creates `temp_dir` for serving the local website. 

Just a small QoL PR, can be closed anytime.