### PR TITLE
Update DNS docs link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,9 +108,7 @@ nav:
       - 'Basic DNSPolicy': multicluster-gateway-controller/docs/dnspolicy/dnspolicy-quickstart.md   
       - 'DNS Health Checks': multicluster-gateway-controller/docs/dnspolicy/dns-health-checks.md
       - 'DNS Providers': multicluster-gateway-controller/docs/dnspolicy/dns-provider.md
-      - 'Advanced DNS based LoadBalancing': multicluster-gateway-controller/docs/dnspolicy/dns-policy/#load-balancing
-      - 'GEO Based DNS LoadBalancing': multicluster-gateway-controller/docs/dnspolicy/dns-policy/#geo
-      - 'Weighted DNS LoadBalancing': multicluster-gateway-controller/docs/dnspolicy/dns-policy/#weighted
+      - 'Advanced DNS based LoadBalancing': multicluster-gateway-controller/docs/how-to/multicluster-loadbalanced-dnspolicy.md
     - 'TLS configuration':
       - 'TLSPolicy and Cert-Manager': multicluster-gateway-controller/docs/tlspolicy/tls-policy.md # new doc needed but this one is ok for now
     - 'Authentication & Authorization':


### PR DESCRIPTION
Updated "How-to Guides/Advanced DNS based LoadBalancing" section to point to multicluster-gateway-controller/docs/how-to/multicluster-loadbalanced-dnspolicy.md. 
Removed "How-to Guides/GEO Based DNS LoadBalancing" and "How-to Guides/Weighted DNS LoadBalancing" since it's all dealt with in the one doc (Also couldn't get the links to work).