### PR TITLE
docs videos & plugin bumps

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 Kuadrant brings together [Gateway API](https://gateway-api.sigs.k8s.io/) and [Open Cluster Management](https://open-cluster-management.io/) to help you scale, load-balance and secure your Ingress Gateways as a key part of your application connectivity, in the single or multi-cluster environment.
 
+<iframe width="100%" height="400" src="https://www.youtube.com/embed/TyhpIQXiPUo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 # Getting Started
 To quickly get started with Kuadrant locally, see our **Getting Started** guides for the [Single Cluster](getting-started-single-cluster.md) or [Multi Cluster](getting-started-multi-cluster.md) use cases.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,8 +23,8 @@ markdown_extensions:
   - attr_list
   - md_in_html
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - footnotes
   - admonition
   - pymdownx.details

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-multirepo-plugin==0.6.1
-mkdocs-material==9.1.17
+mkdocs-multirepo-plugin==0.7.0
+mkdocs-material==9.5.6


### PR DESCRIPTION
Adding some updates to bring some of our videos from our YouTube channel into the docs site.

Also bumps the versions of some of our mkdocs deps to remove some warnings.


Some screenshots:

![Screenshot 2024-02-07 at 18 07 26](https://github.com/Kuadrant/docs.kuadrant.io/assets/4467/c4092330-181f-4889-9929-147299ef83f8)
![Screenshot 2024-02-07 at 18 07 39](https://github.com/Kuadrant/docs.kuadrant.io/assets/4467/0acd1e42-54e1-40af-ad10-3ece21ee547e)
![Screenshot 2024-02-07 at 18 07 50](https://github.com/Kuadrant/docs.kuadrant.io/assets/4467/5c69cd0e-0f18-42e3-b773-1d0219bf7217)
![Screenshot 2024-02-07 at 18 08 01](https://github.com/Kuadrant/docs.kuadrant.io/assets/4467/99fdf8d9-35b4-422b-9ab0-4a06eb549a8b)


