### PR TITLE
import docs/* for kuadrantctl

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ plugins:
           import_url: 'https://github.com/kuadrant/kuadrantctl?edit_uri=/blob/main/&branch=main'
           imports:
             - /README.md
+            - /doc/*
 nav:
   - 'Overview': index.md
   - 'Getting Started':


### PR DESCRIPTION
Fixing some 404's for some of the detailed guides for kuadrantctl.