### PR TITLE
Add kuadrantctl sub guides to side nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -213,3 +213,6 @@ nav:
         - 'Debugging with VSCode': multicluster-gateway-controller/docs/contribution/vscode-debugging.md
     - 'kuadrantctl':
       - 'Getting Started': kuadrantctl/README.md
+      - 'Generating Gateway API HTTPRoutes': kuadrantctl/doc/generate-gateway-api-httproute.md
+      - 'Generating Kuadrant AuthPolicies': kuadrantctl/doc/generate-kuadrant-auth-policy.md
+      - 'Generating Kuadrant RateLimitPolicies': kuadrantctl/doc/generate-kuadrant-rate-limit-policy.md


### PR DESCRIPTION
Part of https://github.com/Kuadrant/kuadrantctl/issues/53

Adds existing guides to sub nav