### PR TITLE
Branding change for Apicurio Studio

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,4 +217,4 @@ nav:
       - 'Generating Kuadrant AuthPolicies': kuadrantctl/doc/generate-kuadrant-auth-policy.md
       - 'Generating Kuadrant RateLimitPolicies': kuadrantctl/doc/generate-kuadrant-rate-limit-policy.md
       - 'CI/CD with kuadrantctl & Tekton': kuadrantctl/doc/kuadrantctl-ci-cd.md
-      - 'Using APICurio with Kuadrant OAS extensions': kuadrantctl/doc/openapi-apicurio.md
+      - 'Using Apicurio Studio with Kuadrant OAS extensions': kuadrantctl/doc/openapi-apicurio.md


### PR DESCRIPTION
Change from `APICurio` to `Apicurio Studio`