### PR TITLE
Use main ref until next release to simplify testing

### DIFF
--- a/docs/getting-started-single-cluster.md
+++ b/docs/getting-started-single-cluster.md
@@ -49,7 +49,7 @@ If you want to make use of the Kuadrant `DNSPolicy` you should setup the followi
 ### Set the release you want to use 
 
 ```bash
-export KUADRANT_REF=v0.6.1
+export KUADRANT_REF=main
 ```
 
 ### Set Up a kind cluster and install Kuadrant


### PR DESCRIPTION
Latest docs changes have not been tested with older 0.6.1 release.
This change will ease the transition to the upcoming release.