### PR TITLE
Adding mike support for multi-versioned docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,9 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install -r requirements.txt
-      - run: mkdocs gh-deploy -s --force
+      - run: |
+          mike set-default 0.6.1
+          mike deploy --push 0.7.0 -t "0.7.0 (dev)"
 
   build:
     if: github.event_name == 'pull_request' || github.event_name == 'schedule'

--- a/README.md
+++ b/README.md
@@ -19,6 +19,33 @@ The docs should then be available locally from http://127.0.0.1:8000/
 
 Outputs static content to `site`.
 
+## `mike`
+We use `mike` for multi-versioned docs. It's quite straight-forward: it works by adding new commits to the `gh-pages` branch each time you run `mike deploy`. It takes care of setting up the aliases, and leaves previously "deployed" docs untouched, in their old folders. These old deployments shouldn't be touched, but can be re-built if necessary.
+
+It  Some useful commands:
+
+List releases:
+
+`mike list`
+
+Build a new release, with a custom title:
+
+`mike deploy 0.7.0 -t "0.7.0 (dev)"`
+
+Delete a release:
+
+`mike delete 0.7.0`
+
+Run a multi-version release:
+
+`mike serve -S`
+
+## Releases
+
+Dev releases from main will always be deployed to "x.x.x (dev)" as a fast channel. The `latest` docs version will always be a known, stable release. The version picker defaults to the latest stable release - newer docs can be found by looking at the latest dev release.
+
+Stable releases should be tagged (e.g. `git tag 0.6.1`).
+
 ## Deploying
 This is deployed via GitHub Pages, on merge to `main`.
 

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1,4 +1,4 @@
-.md-header--shadow {
+.md-header--shadow, .md-header  {
   background-color: #37517e;
   padding: 1em;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,11 @@ site_name: Kuadrant Documentation
 site_url: https://docs.kuadrant.io/
 repo_url: https://github.com/kuadrant/docs.kuadrant.io
 edit_uri: edit/main/docs/
+extra:
+  version:
+    provider: mike
+    default:
+      - 0.6.1
 theme:
   name: material
   logo: assets/images/logo.png
@@ -32,6 +37,14 @@ markdown_extensions:
   - toc:
       permalink: true
 plugins:
+  - mike:
+      alias_type: symlink
+      redirect_template: null
+      deploy_prefix: ''
+      canonical_version: null
+      version_selector: true
+      css_dir: css
+      javascript_dir: js
   - search
   - multirepo:
       cleanup: true

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  These docs are unstable, from our development branches (main).
+  <a href="{{ '../' ~ base_url }}"> 
+    <strong>Click here to go to latest, stable docs.</strong>
+  </a>
+{% endblock %}

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -1,6 +1,6 @@
 <footer id="footer" class="footer">
   <div class="copyright">
-    © Copyright 2023 <strong><span>Kuadrant contributors</span></strong>. All Rights Reserved.
+    © Copyright 2024 <strong><span>Kuadrant contributors</span></strong>. All Rights Reserved.
   </div>
 
   <div class="sponsored-by">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-multirepo-plugin==0.7.0
 mkdocs-material==9.5.14
+mike==2.1.0


### PR DESCRIPTION
![Screenshot 2024-05-03 at 10 49 26](https://github.com/Kuadrant/docs.kuadrant.io/assets/4467/b30995d3-cdb1-48b5-b026-5c7a3a98aa6b)
![Screenshot 2024-05-03 at 10 49 36](https://github.com/Kuadrant/docs.kuadrant.io/assets/4467/145c365f-2449-4a55-a090-182eea0d748b)


Test locally:


```bash
git checkout 0.6.1
mike deploy 0.6.1
mike deploy 0.6.1 "0.6.1 (stable)"
git checkout main
mike deploy 0.7.0 -t "0.7.0 (dev)"
mike set-default 0.6.1
mike serve
```
