### PR TITLE
builds for all branches, deploy only for main.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,20 +4,20 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
     branches:
-      - main
-  # schedule:
-  #   # Runs at 00:00 UTC every day
-  #   - cron: '0 0 * * *'
+      - '**'
 
 permissions:
   contents: write
 
 jobs:
   deploy:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,7 +42,6 @@ jobs:
           mike deploy --push dev -t "dev"
 
   build:
-    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Run `build` step for all PRs
- Only run `deploy` for merges to `main`