### PR TITLE
Fixed broken links in v0.6.1 docs by replacing them with a single link that includes reference to all 3. 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,9 +121,7 @@ nav:
       - 'Basic DNSPolicy': multicluster-gateway-controller/docs/dnspolicy/dnspolicy-quickstart.md   
       - 'DNS Health Checks': multicluster-gateway-controller/docs/dnspolicy/dns-health-checks.md
       - 'DNS Providers': multicluster-gateway-controller/docs/dnspolicy/dns-provider.md
-      - 'Advanced DNS based LoadBalancing': multicluster-gateway-controller/docs/dnspolicy/dns-policy/#load-balancing
-      - 'GEO Based DNS LoadBalancing': multicluster-gateway-controller/docs/dnspolicy/dns-policy/#geo
-      - 'Weighted DNS LoadBalancing': multicluster-gateway-controller/docs/dnspolicy/dns-policy/#weighted
+      - 'Multicluster LoadBalanced DNSPolicy': multicluster-gateway-controller/docs/how-to/multicluster-loadbalanced-dnspolicy.md
     - 'TLS configuration':
       - 'TLSPolicy and Cert-Manager': multicluster-gateway-controller/docs/tlspolicy/tls-policy.md # new doc needed but this one is ok for now
     - 'Authentication & Authorization':


### PR DESCRIPTION
#122 

### What:
Replaced broken links in v0.6.1 docs.

### How:

( Within sidebar )

How-to Guides --> DNS configuration and load balancing ...
--> Advanced DNS based LoadBalancing
--> GEO Based DNS LoadBalancing
-->  Weighted DNS LoadBalancing

**REPLACED BY**

How-to Guides --> DNS configuration and load balancing ...
--> Multicluster LoadBalanced DNSPolicy

Which contains links to Advanced, GEO and Weighted LoadBalancing that can now be accessed by the index bar on the right . 

### Verify:

Run `mkdocs serve` and navigate to aforementioned sidebar refs and ensure content is accessible . 