### PR TITLE
add a dnsprovider setup doc

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,121 +115,123 @@ plugins:
 nav:
   - 'Overview': index.md
   - 'Getting Started':
-    - 'Single-Cluster': getting-started-single-cluster.md
-    - 'Multi-Cluster': getting-started-multi-cluster.md
+      - 'Single-Cluster': getting-started-single-cluster.md
+      - 'Multi-Cluster': getting-started-multi-cluster.md
   - 'Architecture': architecture/docs/design/architectural-overview-v1.md
   - 'Installation':
-    - 'Kubernetes': kuadrant-operator/doc/install/install-kubernetes.md
-    - 'OpenShift': kuadrant-operator/doc/install/install-openshift.md
+      - 'Kubernetes': kuadrant-operator/doc/install/install-kubernetes.md
+      - 'OpenShift': kuadrant-operator/doc/install/install-openshift.md
   - 'Concepts and APIs':
-    - 'DNSPolicy':
-      - 'Overview': kuadrant-operator/doc/dns.md
-      - 'Reference': kuadrant-operator/doc/reference/dnspolicy.md
-      - 'Gateway DNS for Cluster Operators': kuadrant-operator/doc/user-guides/gateway-dns.md
-    - 'TLSPolicy':
-      - 'Overview': kuadrant-operator/doc/tls.md
-      - 'Reference': kuadrant-operator/doc/reference/tlspolicy.md
-    - 'AuthPolicy':
-      - 'Overview': kuadrant-operator/doc/auth.md
-      - 'Reference': kuadrant-operator/doc/reference/authpolicy.md
-    - 'RateLimitPolicy':
-      - 'Overview': kuadrant-operator/doc/rate-limiting.md
-      - 'Reference': kuadrant-operator/doc/reference/ratelimitpolicy.md
+      - 'DNSPolicy':
+          - 'Overview': kuadrant-operator/doc/dns.md
+          - 'Reference': kuadrant-operator/doc/reference/dnspolicy.md
+          - 'Gateway DNS for Cluster Operators': kuadrant-operator/doc/user-guides/gateway-dns.md
+          - 'Configuring DNS Providers': dns-operator/docs/provider.md
+      - 'TLSPolicy':
+          - 'Overview': kuadrant-operator/doc/tls.md
+          - 'Reference': kuadrant-operator/doc/reference/tlspolicy.md
+      - 'AuthPolicy':
+          - 'Overview': kuadrant-operator/doc/auth.md
+          - 'Reference': kuadrant-operator/doc/reference/authpolicy.md
+      - 'RateLimitPolicy':
+          - 'Overview': kuadrant-operator/doc/rate-limiting.md
+          - 'Reference': kuadrant-operator/doc/reference/ratelimitpolicy.md
   - 'How-to Guides':
-    - 'Secure, connect and protect - Kubernetes': kuadrant-operator/doc/user-guides/secure-protect-connect.md
-    - 'Secure, connect and protect - OpenShift': kuadrant-operator/doc/user-guides/secure-protect-connect-single-multi-cluster.md
-    - 'DNS configuration and load balancing':
-      - 'DNS Health Checks': kuadrant-operator/doc/dnshealthchecks.md
-      - 'DNS Providers': dns-operator/docs/provider.md
-    - 'TLS configuration':
-      - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/gateway-tls.md
-    - 'Authentication & Authorization':
-      - 'AuthPolicy for Application Developers and Platform Engineers': kuadrant-operator/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
-      - 'Authentication with Kubernetes tokens (TokenReview API)': authorino/docs/user-guides/kubernetes-tokenreview.md
-      - 'Authentication with API keys': authorino/docs/user-guides/api-key-authentication.md
-      - 'Authentication with X.509 certificates and mTLS': authorino/docs/user-guides/mtls-authentication.md
-      - 'OpenID Connect Discovery and authentication with JWTs': authorino/docs/user-guides/oidc-jwt-authentication.md
-      - 'OAuth 2.0 token introspection (RFC 7662)': authorino/docs/user-guides/oauth2-token-introspection.md
-      - 'Passing credentials (`Authorization` header, cookie headers and others)': authorino/docs/user-guides/passing-credentials.md
-      - 'HTTP "Basic" Authentication (RFC 7235)': authorino/docs/user-guides/http-basic-authentication.md
-      - 'Anonymous access': authorino/docs/user-guides/anonymous-access.md
-      - 'Token normalization': authorino/docs/user-guides/token-normalization.md
-      - 'Edge Authentication Architecture (EAA)': authorino/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
-      - 'Fetching auth metadata from external sources': authorino/docs/user-guides/external-metadata.md
-      - 'OpenID Connect UserInfo': authorino/docs/user-guides/oidc-user-info.md
-      - 'Resource-level authorization with User-Managed Access (UMA) resource registry': authorino/docs/user-guides/resource-level-authorization-uma.md
-      - 'Simple pattern-matching authorization policies': authorino/docs/user-guides/json-pattern-matching-authorization.md
-      - 'OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak': authorino/docs/user-guides/oidc-rbac.md
-      - 'Open Policy Agent (OPA) Rego policies': authorino/docs/user-guides/opa-authorization.md
-      - 'Kubernetes RBAC for service authorization (SubjectAccessReview API)': authorino/docs/user-guides/kubernetes-subjectaccessreview.md
-      - 'Authorization with Keycloak Authorization Services': authorino/docs/user-guides/keycloak-authorization-services.md
-      - 'Integration with Authzed/SpiceDB': authorino/docs/user-guides/authzed.md
-      - 'Injecting data in the request': authorino/docs/user-guides/injecting-data.md
-      - 'Emitting Envoy Dynamic Metadata': authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
-      - 'Redirecting to a login page': authorino/docs/user-guides/deny-with-redirect-to-login.md
-      - 'Reusing Envoy built-in authentication filter result': authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
-      - 'Setting up Kuadrant authorization service as a Validating Webhook': authorino/docs/user-guides/validating-webhook.md
-      - 'Caching': authorino/docs/user-guides/caching.md
-    - 'Rate Limiting':
-      - 'RateLimitPolicy for Platform Engineers': kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
-      - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/authenticated-rl-for-app-developers.md
-      - kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
-    - 'Observability':
-      - 'Metrics': kuadrant-operator/doc/observability/metrics.md
-      - 'Dashboards and Alerts': kuadrant-operator/doc/observability/examples.md
-      - 'Tracing': kuadrant-operator/doc/observability/tracing.md
-      - 'Authentication and Authorization': authorino/docs/user-guides/observability.md
+      - 'Secure, connect and protect - Kubernetes': kuadrant-operator/doc/user-guides/secure-protect-connect.md
+      - 'Secure, connect and protect - OpenShift': kuadrant-operator/doc/user-guides/secure-protect-connect-single-multi-cluster.md
+      - 'DNS configuration':
+          - 'DNS Providers': dns-operator/docs/provider.md
+      - 'TLS configuration':
+          - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/gateway-tls.md
+      - 'Authentication & Authorization':
+          - 'AuthPolicy for Application Developers and Platform Engineers': kuadrant-operator/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
+          - 'Authentication with Kubernetes tokens (TokenReview API)': authorino/docs/user-guides/kubernetes-tokenreview.md
+          - 'Authentication with API keys': authorino/docs/user-guides/api-key-authentication.md
+          - 'Authentication with X.509 certificates and mTLS': authorino/docs/user-guides/mtls-authentication.md
+          - 'OpenID Connect Discovery and authentication with JWTs': authorino/docs/user-guides/oidc-jwt-authentication.md
+          - 'OAuth 2.0 token introspection (RFC 7662)': authorino/docs/user-guides/oauth2-token-introspection.md
+          - 'Passing credentials (`Authorization` header, cookie headers and others)': authorino/docs/user-guides/passing-credentials.md
+          - 'HTTP "Basic" Authentication (RFC 7235)': authorino/docs/user-guides/http-basic-authentication.md
+          - 'Anonymous access': authorino/docs/user-guides/anonymous-access.md
+          - 'Token normalization': authorino/docs/user-guides/token-normalization.md
+          - 'Edge Authentication Architecture (EAA)': authorino/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
+          - 'Fetching auth metadata from external sources': authorino/docs/user-guides/external-metadata.md
+          - 'OpenID Connect UserInfo': authorino/docs/user-guides/oidc-user-info.md
+          - 'Resource-level authorization with User-Managed Access (UMA) resource registry': authorino/docs/user-guides/resource-level-authorization-uma.md
+          - 'Simple pattern-matching authorization policies': authorino/docs/user-guides/json-pattern-matching-authorization.md
+          - 'OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak': authorino/docs/user-guides/oidc-rbac.md
+          - 'Open Policy Agent (OPA) Rego policies': authorino/docs/user-guides/opa-authorization.md
+          - 'Kubernetes RBAC for service authorization (SubjectAccessReview API)': authorino/docs/user-guides/kubernetes-subjectaccessreview.md
+          - 'Authorization with Keycloak Authorization Services': authorino/docs/user-guides/keycloak-authorization-services.md
+          - 'Integration with Authzed/SpiceDB': authorino/docs/user-guides/authzed.md
+          - 'Injecting data in the request': authorino/docs/user-guides/injecting-data.md
+          - 'Emitting Envoy Dynamic Metadata': authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+          - 'Redirecting to a login page': authorino/docs/user-guides/deny-with-redirect-to-login.md
+          - 'Reusing Envoy built-in authentication filter result': authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
+          - 'Setting up Kuadrant authorization service as a Validating Webhook': authorino/docs/user-guides/validating-webhook.md
+          - 'Caching': authorino/docs/user-guides/caching.md
+      - 'Rate Limiting':
+          - 'RateLimitPolicy for Platform Engineers': kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
+          - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/authenticated-rl-for-app-developers.md
+          - kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+      - 'Observability':
+          - 'Metrics': kuadrant-operator/doc/observability/metrics.md
+          - 'Dashboards and Alerts': kuadrant-operator/doc/observability/examples.md
+          - 'Tracing': kuadrant-operator/doc/observability/tracing.md
+          - 'Authentication and Authorization': authorino/docs/user-guides/observability.md
   - 'Experimental':
-    - 'API Quickstart': 'api-quickstart/README.md'
+      - 'API Quickstart': 'api-quickstart/README.md'
   - 'Proposals':
-    - 'Request For Comments (RFC)':
-      - 'RFC 0001: RateLimitPolicy API "v2"': architecture/rfcs/0001-rlp-v2.md
-      - 'RFC 0002: Well-known Attributes': architecture/rfcs/0002-well-known-attributes.md
-      - 'RFC 0003: DNSPolicy': architecture/rfcs/0003-dns-policy.md
-      - 'RFC 0004: Policy Status': architecture/rfcs/0004-policy-status.md
-      - 'RFC 0005: Single Cluster DNSPolicy': architecture/rfcs/0005-single-cluster-dnspolicy.md
-      - 'RFC 0006: Configuration of Kuadrant Sub Components': architecture/rfcs/0006-kuadrant_sub_components_configurations.md
-      - 'RFC 0007: Policy Sync': architecture/rfcs/0007-policy-sync-v1.md
-      - 'RFC 0008: Kuadrant Release Process': architecture/rfcs/0008-kuadrant-release-process.md
-      - 'RFC 0009: Defaults & Overrides': architecture/rfcs/0009-defaults-and-overrides.md
-      - 'RFC 0010: Gateway API Metrics Exporter': architecture/rfcs/0010-gateway-api-metrics-exporter.md
-      - 'RFC 0011: Policy Machinery for reconciliation': architecture/rfcs/0011-policy-machinery.md
+      - 'Request For Comments (RFC)':
+          - 'RFC 0001: RateLimitPolicy API "v2"': architecture/rfcs/0001-rlp-v2.md
+          - 'RFC 0002: Well-known Attributes': architecture/rfcs/0002-well-known-attributes.md
+          - 'RFC 0003: DNSPolicy': architecture/rfcs/0003-dns-policy.md
+          - 'RFC 0004: Policy Status': architecture/rfcs/0004-policy-status.md
+          - 'RFC 0005: Single Cluster DNSPolicy': architecture/rfcs/0005-single-cluster-dnspolicy.md
+          - 'RFC 0006: Configuration of Kuadrant Sub Components': architecture/rfcs/0006-kuadrant_sub_components_configurations.md
+          - 'RFC 0007: Policy Sync': architecture/rfcs/0007-policy-sync-v1.md
+          - 'RFC 0008: Kuadrant Release Process': architecture/rfcs/0008-kuadrant-release-process.md
+          - 'RFC 0009: Defaults & Overrides': architecture/rfcs/0009-defaults-and-overrides.md
+          - 'RFC 0010: Gateway API Metrics Exporter': architecture/rfcs/0010-gateway-api-metrics-exporter.md
+          - 'RFC 0011: Policy Machinery for reconciliation': architecture/rfcs/0011-policy-machinery.md
   - 'Components':
-    - 'Kuadrant Operator':
-      - 'Overview': kuadrant-operator/README.md
-      - "Developer's Guide": kuadrant-operator/doc/development.md
-      - kuadrant-operator/doc/logging.md
-    - 'Authorino':
-      - 'Overview': authorino/README.md
-      - 'Authorino Operator': authorino-operator/README.md
-      - 'Getting Started': authorino/docs/getting-started.md
-      - 'Hello World': authorino/docs/user-guides/hello-world.md
-      - 'Architecture': authorino/docs/architecture.md
-      - 'Reference': authorino/docs/features.md
-      - 'Advanced features':
-        - 'Host override via context extension': authorino/docs/user-guides/host-override.md
-        - 'Reducing the operational space: sharding, noise and multi-tenancy': authorino/docs/user-guides/sharding.md
-      - "Developer's Guide": authorino/docs/contributing.md
-    - 'Limitador':
-      - 'Overview': limitador/README.md
-      - 'How it works': limitador/doc/how-it-works.md
-      - 'Topologies': limitador/doc/topologies.md
-      - 'Server':
-        - 'Overview': limitador/limitador-server/README.md
-        - 'Kubernetes': limitador/limitador-server/kubernetes/README.md
-        - 'Sandbox': limitador/limitador-server/sandbox/README.md
-      - 'Crate': limitador/limitador/README.md
-      - 'Limitador Operator':
-        - 'Overview': limitador-operator/README.md
-        - 'Storage': limitador-operator/doc/storage.md
-        - 'Rate limit headers': limitador-operator/doc/rate-limit-headers.md
-        - "Developer's Guide": limitador-operator/doc/development.md
-        - limitador-operator/doc/logging.md
-    - 'kuadrantctl':
-      - 'Getting Started': kuadrantctl/README.md
-      - 'Generating Gateway API HTTPRoutes': kuadrantctl/doc/generate-gateway-api-httproute.md
-      - 'Generating Kuadrant AuthPolicies': kuadrantctl/doc/generate-kuadrant-auth-policy.md
-      - 'Generating Kuadrant RateLimitPolicies': kuadrantctl/doc/generate-kuadrant-rate-limit-policy.md
-      - 'CI/CD with kuadrantctl & Tekton': kuadrantctl/doc/kuadrantctl-ci-cd.md
-      - 'Using Apicurio Studio with Kuadrant OAS extensions': kuadrantctl/doc/openapi-apicurio.md
-      - 'Using OpenShift Dev Spaces with Kuadrant OAS extensions': kuadrantctl/doc/openapi-openshift-dev-spaces.md
+      - 'Kuadrant Operator':
+          - 'Overview': kuadrant-operator/README.md
+          - "Developer's Guide": kuadrant-operator/doc/development.md
+          - kuadrant-operator/doc/logging.md
+      - 'Authorino':
+          - 'Overview': authorino/README.md
+          - 'Authorino Operator': authorino-operator/README.md
+          - 'Getting Started': authorino/docs/getting-started.md
+          - 'Hello World': authorino/docs/user-guides/hello-world.md
+          - 'Architecture': authorino/docs/architecture.md
+          - 'Reference': authorino/docs/features.md
+          - 'Advanced features':
+              - 'Host override via context extension': authorino/docs/user-guides/host-override.md
+              - 'Reducing the operational space: sharding, noise and multi-tenancy': authorino/docs/user-guides/sharding.md
+          - "Developer's Guide": authorino/docs/contributing.md
+      - 'Limitador':
+          - 'Overview': limitador/README.md
+          - 'How it works': limitador/doc/how-it-works.md
+          - 'Topologies': limitador/doc/topologies.md
+          - 'Server':
+              - 'Overview': limitador/limitador-server/README.md
+              - 'Kubernetes': limitador/limitador-server/kubernetes/README.md
+              - 'Sandbox': limitador/limitador-server/sandbox/README.md
+          - 'Crate': limitador/limitador/README.md
+          - 'Limitador Operator':
+              - 'Overview': limitador-operator/README.md
+              - 'Storage': limitador-operator/doc/storage.md
+              - 'Rate limit headers': limitador-operator/doc/rate-limit-headers.md
+              - "Developer's Guide": limitador-operator/doc/development.md
+              - limitador-operator/doc/logging.md
+          - 'DNS Operator':
+              - 'Overview': dns-operator/README.md
+      - 'kuadrantctl':
+          - 'Getting Started': kuadrantctl/README.md
+          - 'Generating Gateway API HTTPRoutes': kuadrantctl/doc/generate-gateway-api-httproute.md
+          - 'Generating Kuadrant AuthPolicies': kuadrantctl/doc/generate-kuadrant-auth-policy.md
+          - 'Generating Kuadrant RateLimitPolicies': kuadrantctl/doc/generate-kuadrant-rate-limit-policy.md
+          - 'CI/CD with kuadrantctl & Tekton': kuadrantctl/doc/kuadrantctl-ci-cd.md
+          - 'Using Apicurio Studio with Kuadrant OAS extensions': kuadrantctl/doc/openapi-apicurio.md
+          - 'Using OpenShift Dev Spaces with Kuadrant OAS extensions': kuadrantctl/doc/openapi-openshift-dev-spaces.md


### PR DESCRIPTION
We seemed to have single and double quotes. My editor freaked and set them all to single. Hope this is ok


Signed-off-by: craig <cbrookes@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED