### PR TITLE
Fix the website directories

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Kuadrant Documentation
 site_url: https://docs.kuadrant.io/
-repo_url: https://github.com/R-Lawton/docs.kuadrant.io
+repo_url: https://github.com/kuadrant/docs.kuadrant.io
 edit_uri: edit/main/docs/
 extra:
   version:
@@ -65,18 +65,18 @@ plugins:
             - /config/samples/*
             - /examples/*
         - name: authorino
-          import_url: "https://github.com/R-Lawton/authorino?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: "https://github.com/kuadrant/authorino?edit_uri=/blob/main/&branch=main"
           imports:
             - /README.md
             - /docs/*
             - /docs/user-guides/*
             - /install/crd/*
         - name: authorino-operator
-          import_url: "https://github.com/R-Lawton/authorino-operator?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: "https://github.com/kuadrant/authorino-operator?edit_uri=/blob/main/&branch=main"
           imports:
             - /README.md
         - name: limitador
-          import_url: "https://github.com/R-Lawton/limitador?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: "https://github.com/kuadrant/limitador?edit_uri=/blob/main/&branch=main"
           imports:
             - /README.md
             - /doc/*
@@ -87,27 +87,27 @@ plugins:
             - /limitador-server/sandbox/*
             - /LICENSE
         - name: limitador-operator
-          import_url: "https://github.com/R-Lawton/limitador-operator?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: "https://github.com/kuadrant/limitador-operator?edit_uri=/blob/main/&branch=main"
           imports:
             - /README.md
             - /doc/*
         - name: architecture
-          import_url: "https://github.com/R-Lawton/architecture?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: "https://github.com/kuadrant/architecture?edit_uri=/blob/main/&branch=main"
           imports:
             - /rfcs/*
             - /docs/*
         - name: api-quickstart
-          import_url: "https://github.com/R-Lawton/api-quickstart?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: "https://github.com/kuadrant/api-quickstart?edit_uri=/blob/main/&branch=main"
           imports:
             - /README.md
             - /images/*
         - name: kuadrantctl
-          import_url: "https://github.com/R-Lawton/kuadrantctl?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: "https://github.com/kuadrant/kuadrantctl?edit_uri=/blob/main/&branch=main"
           imports:
             - /README.md
             - /doc/*
         - name: dns-operator
-          import_url: "https://github.com/R-Lawton/dns-operator?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: "https://github.com/kuadrant/dns-operator?edit_uri=/blob/main/&branch=main"
           imports:
             - /README.md
             - /docs/*
@@ -122,31 +122,36 @@ nav:
   - "Installation":
       - "Kubernetes": kuadrant-operator/doc/install/install-kubernetes.md
       - "OpenShift": kuadrant-operator/doc/install/install-openshift.md
+      - "From Source": kuadrant-operator/doc/install/install-make.md
   - "Concepts and APIs":
       - "DNSPolicy":
-          - "Overview": kuadrant-operator/doc/dns.md
+          - "Overview": kuadrant-operator/doc/overviews/dns.md
           - "Reference": kuadrant-operator/doc/reference/dnspolicy.md
       - "TLSPolicy":
-          - "Overview": kuadrant-operator/doc/tls.md
+          - "Overview": kuadrant-operator/doc/overviews/tls.md
           - "Reference": kuadrant-operator/doc/reference/tlspolicy.md
       - "AuthPolicy":
-          - "Overview": kuadrant-operator/doc/auth.md
+          - "Overview": kuadrant-operator/doc/overviews/auth.md
           - "Reference": kuadrant-operator/doc/reference/authpolicy.md
       - "RateLimitPolicy":
-          - "Overview": kuadrant-operator/doc/rate-limiting.md
+          - "Overview": kuadrant-operator/doc/overviews/rate-limiting.md
           - "Reference": kuadrant-operator/doc/reference/ratelimitpolicy.md
   - "How-to Guides":
       - "Secure, connect and protect (Full Walkthrough)":
-          - "Kubernetes": kuadrant-operator/doc/user-guides/secure-protect-connect.md
-          - "OpenShift": kuadrant-operator/doc/user-guides/secure-protect-connect-single-multi-cluster.md
+          - "Kubernetes": kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-k8s.md
+          - "OpenShift": kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-openshift.md
       - "DNS configuration":
-          - "Gateway DNS for Cluster Operators": kuadrant-operator/doc/user-guides/gateway-dns.md
+          - "Gateway DNS for Cluster Operators": kuadrant-operator/doc/user-guides/dns/gateway-dns.md
           - "Configuring DNS Providers": dns-operator/docs/provider.md
+          - "Basic DNS configuration": kuadrant-operator/doc/user-guides/dns/basic-dns-configuration.md
+          - "DNS health checks": kuadrant-operator/doc/user-guides/dns/dnshealthchecks.md
+          - "Orphaned DNS Records": kuadrant-operator/doc/user-guides/dns/orphaned-dns-records.md
+          - "DNS excluding specific addresses": kuadrant-operator/doc/user-guides/dns/dns-excluding-specific-addresses.md
       - "TLS configuration":
-          - "Gateway TLS for Cluster Operators": kuadrant-operator/doc/user-guides/gateway-tls.md
+          - "Gateway TLS for Cluster Operators": kuadrant-operator/doc/user-guides/tls/gateway-tls.md
       - "Authentication & Authorization configuration":
           - "Authentication":
-              - "AuthPolicy for Application Developers and Platform Engineers": kuadrant-operator/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
+              - "AuthPolicy for Application Developers and Platform Engineers": kuadrant-operator/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
               - "Authentication with Kubernetes tokens (TokenReview API)": authorino/docs/user-guides/kubernetes-tokenreview.md
               - "Authentication with API keys": authorino/docs/user-guides/api-key-authentication.md
               - "Authentication with X.509 certificates and mTLS": authorino/docs/user-guides/mtls-authentication.md
@@ -179,8 +184,8 @@ nav:
               - "OAuth 2.0 token introspection (RFC 7662)": authorino/docs/user-guides/oauth2-token-introspection.md
       - "Rate Limiting configuration":
           - "RateLimitPolicy for Platform Engineers": kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
-          - "Authenticated Rate Limiting for Application Developers": kuadrant-operator/doc/user-guides/authenticated-rl-for-app-developers.md
-          - kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+          - "Authenticated Rate Limiting for Application Developers": kuadrant-operator/doc/user-guides/authenticated-rl-for-app.md
+          - "Authenticated Rate Limiting with JWTs and Kubernetes RBAC": kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
       - "Observability configuration":
           - "Metrics": kuadrant-operator/doc/observability/metrics.md
           - "Dashboards and Alerts": kuadrant-operator/doc/observability/examples.md
@@ -202,7 +207,8 @@ nav:
           - "RFC 0010: Gateway API Metrics Exporter": architecture/rfcs/0010-gateway-api-metrics-exporter.md
           - "RFC 0011: Policy Machinery for reconciliation": architecture/rfcs/0011-policy-machinery.md
   - "Components":
-      - "Kuadrant Operator": https://github.com/R-Lawton/docs.kuadrant.io
-      - "Authorino": https://github.com/R-Lawton/docs.kuadrant.io
-      - "Limitador": https://github.com/R-Lawton/docs.kuadrant.io
-      - "kuadrantctl": https://github.com/R-Lawton/docs.kuadrant.io
+      - "Kuadrant Operator": https://github.com/kuadrant/docs.kuadrant.io
+      - "Authorino": https://github.com/kuadrant/docs.kuadrant.io
+      - "Limitador": https://github.com/kuadrant/docs.kuadrant.io
+      - "kuadrantctl": https://github.com/kuadrant/docs.kuadrant.io
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Kuadrant Documentation
 site_url: https://docs.kuadrant.io/
-repo_url: https://github.com/kuadrant/docs.kuadrant.io
+repo_url: https://github.com/R-Lawton/docs.kuadrant.io
 edit_uri: edit/main/docs/
 extra:
   version:
@@ -47,7 +47,7 @@ plugins:
   - mike:
       alias_type: symlink
       redirect_template: null
-      deploy_prefix: ''
+      deploy_prefix: ""
       canonical_version: null
       version_selector: true
       css_dir: css
@@ -58,25 +58,25 @@ plugins:
       keep_docs_dir: true
       nav_repos:
         - name: kuadrant-operator
-          import_url: 'https://github.com/kuadrant/kuadrant-operator?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/kuadrant-operator?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /README.md
             - /doc/*
             - /config/samples/*
             - /examples/*
         - name: authorino
-          import_url: 'https://github.com/kuadrant/authorino?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/authorino?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /README.md
             - /docs/*
             - /docs/user-guides/*
             - /install/crd/*
         - name: authorino-operator
-          import_url: 'https://github.com/kuadrant/authorino-operator?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/authorino-operator?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /README.md
         - name: limitador
-          import_url: 'https://github.com/kuadrant/limitador?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/limitador?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /README.md
             - /doc/*
@@ -87,152 +87,122 @@ plugins:
             - /limitador-server/sandbox/*
             - /LICENSE
         - name: limitador-operator
-          import_url: 'https://github.com/kuadrant/limitador-operator?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/limitador-operator?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /README.md
             - /doc/*
         - name: architecture
-          import_url: 'https://github.com/kuadrant/architecture?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/architecture?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /rfcs/*
             - /docs/*
         - name: api-quickstart
-          import_url: 'https://github.com/kuadrant/api-quickstart?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/api-quickstart?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /README.md
             - /images/*
         - name: kuadrantctl
-          import_url: 'https://github.com/kuadrant/kuadrantctl?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/kuadrantctl?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /README.md
             - /doc/*
         - name: dns-operator
-          import_url: 'https://github.com/kuadrant/dns-operator?edit_uri=/blob/main/&branch=main'
+          import_url: "https://github.com/R-Lawton/dns-operator?edit_uri=/blob/main/&branch=doc-updates"
           imports:
             - /README.md
             - /docs/*
             - /config/samples/*
 nav:
-  - 'Overview': index.md
-  - 'Getting Started':
-      - 'Single-Cluster': getting-started-single-cluster.md
-      - 'Multi-Cluster': getting-started-multi-cluster.md
-  - 'Architecture': architecture/docs/design/architectural-overview-v1.md
-  - 'Installation':
-      - 'Kubernetes': kuadrant-operator/doc/install/install-kubernetes.md
-      - 'OpenShift': kuadrant-operator/doc/install/install-openshift.md
-  - 'Concepts and APIs':
-      - 'DNSPolicy':
-          - 'Overview': kuadrant-operator/doc/dns.md
-          - 'Reference': kuadrant-operator/doc/reference/dnspolicy.md
-          - 'Gateway DNS for Cluster Operators': kuadrant-operator/doc/user-guides/gateway-dns.md
-          - 'Configuring DNS Providers': dns-operator/docs/provider.md
-      - 'TLSPolicy':
-          - 'Overview': kuadrant-operator/doc/tls.md
-          - 'Reference': kuadrant-operator/doc/reference/tlspolicy.md
-      - 'AuthPolicy':
-          - 'Overview': kuadrant-operator/doc/auth.md
-          - 'Reference': kuadrant-operator/doc/reference/authpolicy.md
-      - 'RateLimitPolicy':
-          - 'Overview': kuadrant-operator/doc/rate-limiting.md
-          - 'Reference': kuadrant-operator/doc/reference/ratelimitpolicy.md
-  - 'How-to Guides':
-      - 'Secure, connect and protect - Kubernetes': kuadrant-operator/doc/user-guides/secure-protect-connect.md
-      - 'Secure, connect and protect - OpenShift': kuadrant-operator/doc/user-guides/secure-protect-connect-single-multi-cluster.md
-      - 'DNS configuration':
-          - 'DNS Providers': dns-operator/docs/provider.md
-      - 'TLS configuration':
-          - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/gateway-tls.md
-      - 'Authentication & Authorization':
-          - 'AuthPolicy for Application Developers and Platform Engineers': kuadrant-operator/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
-      - 'Rate Limiting':
-          - 'RateLimitPolicy for Platform Engineers': kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
-          - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/authenticated-rl-for-app-developers.md
+  - "Introduction":
+      - "Overview": index.md
+      - "Architecture": architecture/docs/design/architectural-overview-v1.md
+  - "Getting Started":
+      - "Single-Cluster": getting-started-single-cluster.md
+      - "Multi-Cluster": getting-started-multi-cluster.md
+  - "Installation":
+      - "Kubernetes": kuadrant-operator/doc/install/install-kubernetes.md
+      - "OpenShift": kuadrant-operator/doc/install/install-openshift.md
+  - "Concepts and APIs":
+      - "DNSPolicy":
+          - "Overview": kuadrant-operator/doc/dns.md
+          - "Reference": kuadrant-operator/doc/reference/dnspolicy.md
+      - "TLSPolicy":
+          - "Overview": kuadrant-operator/doc/tls.md
+          - "Reference": kuadrant-operator/doc/reference/tlspolicy.md
+      - "AuthPolicy":
+          - "Overview": kuadrant-operator/doc/auth.md
+          - "Reference": kuadrant-operator/doc/reference/authpolicy.md
+      - "RateLimitPolicy":
+          - "Overview": kuadrant-operator/doc/rate-limiting.md
+          - "Reference": kuadrant-operator/doc/reference/ratelimitpolicy.md
+  - "How-to Guides":
+      - "Secure, connect and protect (Full Walkthrough)":
+          - "Kubernetes": kuadrant-operator/doc/user-guides/secure-protect-connect.md
+          - "OpenShift": kuadrant-operator/doc/user-guides/secure-protect-connect-single-multi-cluster.md
+      - "DNS configuration":
+          - "Gateway DNS for Cluster Operators": kuadrant-operator/doc/user-guides/gateway-dns.md
+          - "Configuring DNS Providers": dns-operator/docs/provider.md
+      - "TLS configuration":
+          - "Gateway TLS for Cluster Operators": kuadrant-operator/doc/user-guides/gateway-tls.md
+      - "Authentication & Authorization configuration":
+          - "Authentication":
+              - "AuthPolicy for Application Developers and Platform Engineers": kuadrant-operator/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
+              - "Authentication with Kubernetes tokens (TokenReview API)": authorino/docs/user-guides/kubernetes-tokenreview.md
+              - "Authentication with API keys": authorino/docs/user-guides/api-key-authentication.md
+              - "Authentication with X.509 certificates and mTLS": authorino/docs/user-guides/mtls-authentication.md
+              - "Authentication with HTTP 'Basic'": authorino/docs/user-guides/http-basic-authentication.md
+              - "Edge Authentication Architecture (EAA)": authorino/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
+              - "OIDC":
+                  - "OpenID Connect Discovery and authentication with JWTs": authorino/docs/user-guides/oidc-jwt-authentication.md
+                  - "OpenID Connect UserInfo": authorino/docs/user-guides/oidc-user-info.md
+                  - "OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak": authorino/docs/user-guides/oidc-rbac.md
+          - "Authorization":
+              - "Passing credentials (`Authorization` header, cookie headers and others)": authorino/docs/user-guides/passing-credentials.md
+              - "Resource-level authorization with User-Managed Access (UMA) resource registry": authorino/docs/user-guides/resource-level-authorization-uma.md
+              - "Authorization with Keycloak Authorization Services": authorino/docs/user-guides/keycloak-authorization-services.md
+              - "Simple pattern-matching authorization policies": authorino/docs/user-guides/json-pattern-matching-authorization.md
+              - "Kubernetes RBAC for service authorization (SubjectAccessReview API)": authorino/docs/user-guides/kubernetes-subjectaccessreview.md
+              - "Setting up Kuadrant authorization service as a Validating Webhook": authorino/docs/user-guides/validating-webhook.md
+              - "OPA Rego":
+                  - "Open Policy Agent (OPA) Rego policies": authorino/docs/user-guides/opa-authorization.md
+              - "Envoy":
+                  - "Emitting Envoy Dynamic Metadata": authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+                  - "Reusing Envoy built-in authentication filter result": authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
+          - "Authorization Infrastructure and Management":
+              - "Anonymous access": authorino/docs/user-guides/anonymous-access.md
+              - "Token normalization": authorino/docs/user-guides/token-normalization.md
+              - "Fetching auth metadata from external sources": authorino/docs/user-guides/external-metadata.md
+              - "Integration with Authzed/SpiceDB": authorino/docs/user-guides/authzed.md
+              - "Injecting data in the request": authorino/docs/user-guides/injecting-data.md
+              - "Redirecting to a login page": authorino/docs/user-guides/deny-with-redirect-to-login.md
+              - "Caching": authorino/docs/user-guides/caching.md
+              - "OAuth 2.0 token introspection (RFC 7662)": authorino/docs/user-guides/oauth2-token-introspection.md
+      - "Rate Limiting configuration":
+          - "RateLimitPolicy for Platform Engineers": kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
+          - "Authenticated Rate Limiting for Application Developers": kuadrant-operator/doc/user-guides/authenticated-rl-for-app-developers.md
           - kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
-      - 'Observability':
-          - 'Metrics': kuadrant-operator/doc/observability/metrics.md
-          - 'Dashboards and Alerts': kuadrant-operator/doc/observability/examples.md
-          - 'Tracing': kuadrant-operator/doc/observability/tracing.md
-          - 'Authentication and Authorization': authorino/docs/user-guides/observability.md
-  - 'Experimental':
-      - 'API Quickstart': 'api-quickstart/README.md'
-  - 'Proposals':
-      - 'Request For Comments (RFC)':
+      - "Observability configuration":
+          - "Metrics": kuadrant-operator/doc/observability/metrics.md
+          - "Dashboards and Alerts": kuadrant-operator/doc/observability/examples.md
+          - "Tracing": kuadrant-operator/doc/observability/tracing.md
+          - "Authentication and Authorization": authorino/docs/user-guides/observability.md
+  - "Experimental":
+      - "API Quickstart": "api-quickstart/README.md"
+  - "Proposals":
+      - "Request For Comments (RFC)":
           - 'RFC 0001: RateLimitPolicy API "v2"': architecture/rfcs/0001-rlp-v2.md
-          - 'RFC 0002: Well-known Attributes': architecture/rfcs/0002-well-known-attributes.md
-          - 'RFC 0003: DNSPolicy': architecture/rfcs/0003-dns-policy.md
-          - 'RFC 0004: Policy Status': architecture/rfcs/0004-policy-status.md
-          - 'RFC 0005: Single Cluster DNSPolicy': architecture/rfcs/0005-single-cluster-dnspolicy.md
-          - 'RFC 0006: Configuration of Kuadrant Sub Components': architecture/rfcs/0006-kuadrant_sub_components_configurations.md
-          - 'RFC 0007: Policy Sync': architecture/rfcs/0007-policy-sync-v1.md
-          - 'RFC 0008: Kuadrant Release Process': architecture/rfcs/0008-kuadrant-release-process.md
-          - 'RFC 0009: Defaults & Overrides': architecture/rfcs/0009-defaults-and-overrides.md
-          - 'RFC 0010: Gateway API Metrics Exporter': architecture/rfcs/0010-gateway-api-metrics-exporter.md
-          - 'RFC 0011: Policy Machinery for reconciliation': architecture/rfcs/0011-policy-machinery.md
-  - 'Components':
-      - 'Kuadrant Operator':
-          - 'Overview': kuadrant-operator/README.md
-          - "Developer's Guide": kuadrant-operator/doc/development.md
-          - kuadrant-operator/doc/logging.md
-      - 'Authorino':
-          - 'Overview': authorino/README.md
-          - 'Authorino Operator': authorino-operator/README.md
-          - 'Getting Started': authorino/docs/getting-started.md
-          - 'Hello World': authorino/docs/user-guides/hello-world.md
-          - 'User Guides':
-            - 'Authentication with Kubernetes tokens (TokenReview API)': authorino/docs/user-guides/kubernetes-tokenreview.md
-            - 'Authentication with API keys': authorino/docs/user-guides/api-key-authentication.md
-            - 'Authentication with X.509 certificates and mTLS': authorino/docs/user-guides/mtls-authentication.md
-            - 'OpenID Connect Discovery and authentication with JWTs': authorino/docs/user-guides/oidc-jwt-authentication.md
-            - 'OAuth 2.0 token introspection (RFC 7662)': authorino/docs/user-guides/oauth2-token-introspection.md
-            - 'Passing credentials (`Authorization` header, cookie headers and others)': authorino/docs/user-guides/passing-credentials.md
-            - 'HTTP "Basic" Authentication (RFC 7235)': authorino/docs/user-guides/http-basic-authentication.md
-            - 'Anonymous access': authorino/docs/user-guides/anonymous-access.md
-            - 'Token normalization': authorino/docs/user-guides/token-normalization.md
-            - 'Edge Authentication Architecture (EAA)': authorino/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
-            - 'Fetching auth metadata from external sources': authorino/docs/user-guides/external-metadata.md
-            - 'OpenID Connect UserInfo': authorino/docs/user-guides/oidc-user-info.md
-            - 'Resource-level authorization with User-Managed Access (UMA) resource registry': authorino/docs/user-guides/resource-level-authorization-uma.md
-            - 'Simple pattern-matching authorization policies': authorino/docs/user-guides/json-pattern-matching-authorization.md
-            - 'OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak': authorino/docs/user-guides/oidc-rbac.md
-            - 'Open Policy Agent (OPA) Rego policies': authorino/docs/user-guides/opa-authorization.md
-            - 'Kubernetes RBAC for service authorization (SubjectAccessReview API)': authorino/docs/user-guides/kubernetes-subjectaccessreview.md
-            - 'Authorization with Keycloak Authorization Services': authorino/docs/user-guides/keycloak-authorization-services.md
-            - 'Integration with Authzed/SpiceDB': authorino/docs/user-guides/authzed.md
-            - 'Injecting data in the request': authorino/docs/user-guides/injecting-data.md
-            - 'Emitting Envoy Dynamic Metadata': authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
-            - 'Redirecting to a login page': authorino/docs/user-guides/deny-with-redirect-to-login.md
-            - 'Reusing Envoy built-in authentication filter result': authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
-            - 'Setting up Kuadrant authorization service as a Validating Webhook': authorino/docs/user-guides/validating-webhook.md
-            - 'Caching': authorino/docs/user-guides/caching.md
-          - 'Architecture': authorino/docs/architecture.md
-          - 'Reference': authorino/docs/features.md
-          - 'Advanced features':
-              - 'Host override via context extension': authorino/docs/user-guides/host-override.md
-              - 'Reducing the operational space: sharding, noise and multi-tenancy': authorino/docs/user-guides/sharding.md
-          - "Developer's Guide": authorino/docs/contributing.md
-      - 'Limitador':
-          - 'Overview': limitador/README.md
-          - 'How it works': limitador/doc/how-it-works.md
-          - 'Topologies': limitador/doc/topologies.md
-          - 'Server':
-              - 'Overview': limitador/limitador-server/README.md
-              - 'Kubernetes': limitador/limitador-server/kubernetes/README.md
-              - 'Sandbox': limitador/limitador-server/sandbox/README.md
-          - 'Crate': limitador/limitador/README.md
-          - 'Limitador Operator':
-              - 'Overview': limitador-operator/README.md
-              - 'Storage': limitador-operator/doc/storage.md
-              - 'Rate limit headers': limitador-operator/doc/rate-limit-headers.md
-              - "Developer's Guide": limitador-operator/doc/development.md
-              - limitador-operator/doc/logging.md
-          - 'DNS Operator':
-              - 'Overview': dns-operator/README.md
-      - 'kuadrantctl':
-          - 'Getting Started': kuadrantctl/README.md
-          - 'Generating Gateway API HTTPRoutes': kuadrantctl/doc/generate-gateway-api-httproute.md
-          - 'Generating Kuadrant AuthPolicies': kuadrantctl/doc/generate-kuadrant-auth-policy.md
-          - 'Generating Kuadrant RateLimitPolicies': kuadrantctl/doc/generate-kuadrant-rate-limit-policy.md
-          - 'CI/CD with kuadrantctl & Tekton': kuadrantctl/doc/kuadrantctl-ci-cd.md
-          - 'Using Apicurio Studio with Kuadrant OAS extensions': kuadrantctl/doc/openapi-apicurio.md
-          - 'Using OpenShift Dev Spaces with Kuadrant OAS extensions': kuadrantctl/doc/openapi-openshift-dev-spaces.md
+          - "RFC 0002: Well-known Attributes": architecture/rfcs/0002-well-known-attributes.md
+          - "RFC 0003: DNSPolicy": architecture/rfcs/0003-dns-policy.md
+          - "RFC 0004: Policy Status": architecture/rfcs/0004-policy-status.md
+          - "RFC 0005: Single Cluster DNSPolicy": architecture/rfcs/0005-single-cluster-dnspolicy.md
+          - "RFC 0006: Configuration of Kuadrant Sub Components": architecture/rfcs/0006-kuadrant_sub_components_configurations.md
+          - "RFC 0007: Policy Sync": architecture/rfcs/0007-policy-sync-v1.md
+          - "RFC 0008: Kuadrant Release Process": architecture/rfcs/0008-kuadrant-release-process.md
+          - "RFC 0009: Defaults & Overrides": architecture/rfcs/0009-defaults-and-overrides.md
+          - "RFC 0010: Gateway API Metrics Exporter": architecture/rfcs/0010-gateway-api-metrics-exporter.md
+          - "RFC 0011: Policy Machinery for reconciliation": architecture/rfcs/0011-policy-machinery.md
+  - "Components":
+      - "Kuadrant Operator": https://github.com/R-Lawton/docs.kuadrant.io
+      - "Authorino": https://github.com/R-Lawton/docs.kuadrant.io
+      - "Limitador": https://github.com/R-Lawton/docs.kuadrant.io
+      - "kuadrantctl": https://github.com/R-Lawton/docs.kuadrant.io

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,7 @@ plugins:
   - mike:
       alias_type: symlink
       redirect_template: null
-      deploy_prefix: ""
+      deploy_prefix: ''
       canonical_version: null
       version_selector: true
       css_dir: css
@@ -58,25 +58,25 @@ plugins:
       keep_docs_dir: true
       nav_repos:
         - name: kuadrant-operator
-          import_url: "https://github.com/R-Lawton/kuadrant-operator?edit_uri=/blob/main/&branch=doc-updates"
+          import_url: 'https://github.com/R-Lawton/kuadrant-operator?edit_uri=/blob/main/&branch=doc-updates'
           imports:
             - /README.md
             - /doc/*
             - /config/samples/*
             - /examples/*
         - name: authorino
-          import_url: "https://github.com/kuadrant/authorino?edit_uri=/blob/main/&branch=main"
+          import_url: 'https://github.com/kuadrant/authorino?edit_uri=/blob/main/&branch=main'
           imports:
             - /README.md
             - /docs/*
             - /docs/user-guides/*
             - /install/crd/*
         - name: authorino-operator
-          import_url: "https://github.com/kuadrant/authorino-operator?edit_uri=/blob/main/&branch=main"
+          import_url: 'https://github.com/kuadrant/authorino-operator?edit_uri=/blob/main/&branch=main'
           imports:
             - /README.md
         - name: limitador
-          import_url: "https://github.com/kuadrant/limitador?edit_uri=/blob/main/&branch=main"
+          import_url: 'https://github.com/kuadrant/limitador?edit_uri=/blob/main/&branch=main'
           imports:
             - /README.md
             - /doc/*
@@ -87,128 +87,128 @@ plugins:
             - /limitador-server/sandbox/*
             - /LICENSE
         - name: limitador-operator
-          import_url: "https://github.com/kuadrant/limitador-operator?edit_uri=/blob/main/&branch=main"
+          import_url: 'https://github.com/kuadrant/limitador-operator?edit_uri=/blob/main/&branch=main'
           imports:
             - /README.md
             - /doc/*
         - name: architecture
-          import_url: "https://github.com/kuadrant/architecture?edit_uri=/blob/main/&branch=main"
+          import_url: 'https://github.com/kuadrant/architecture?edit_uri=/blob/main/&branch=main'
           imports:
             - /rfcs/*
             - /docs/*
         - name: api-quickstart
-          import_url: "https://github.com/kuadrant/api-quickstart?edit_uri=/blob/main/&branch=main"
+          import_url: 'https://github.com/kuadrant/api-quickstart?edit_uri=/blob/main/&branch=main'
           imports:
             - /README.md
             - /images/*
         - name: kuadrantctl
-          import_url: "https://github.com/kuadrant/kuadrantctl?edit_uri=/blob/main/&branch=main"
+          import_url: 'https://github.com/kuadrant/kuadrantctl?edit_uri=/blob/main/&branch=main'
           imports:
             - /README.md
             - /doc/*
         - name: dns-operator
-          import_url: "https://github.com/kuadrant/dns-operator?edit_uri=/blob/main/&branch=main"
+          import_url: 'https://github.com/kuadrant/dns-operator?edit_uri=/blob/main/&branch=main'
           imports:
             - /README.md
             - /docs/*
             - /config/samples/*
 nav:
-  - "Introduction":
-      - "Overview": index.md
-      - "Architecture": architecture/docs/design/architectural-overview-v1.md
-  - "Getting Started":
-      - "Single-Cluster": getting-started-single-cluster.md
-      - "Multi-Cluster": getting-started-multi-cluster.md
-  - "Installation":
-      - "Kubernetes": kuadrant-operator/doc/install/install-kubernetes.md
-      - "OpenShift": kuadrant-operator/doc/install/install-openshift.md
-      - "From Source": kuadrant-operator/doc/install/install-make.md
-  - "Concepts and APIs":
-      - "DNSPolicy":
-          - "Overview": kuadrant-operator/doc/overviews/dns.md
-          - "Reference": kuadrant-operator/doc/reference/dnspolicy.md
-      - "TLSPolicy":
-          - "Overview": kuadrant-operator/doc/overviews/tls.md
-          - "Reference": kuadrant-operator/doc/reference/tlspolicy.md
-      - "AuthPolicy":
-          - "Overview": kuadrant-operator/doc/overviews/auth.md
-          - "Reference": kuadrant-operator/doc/reference/authpolicy.md
-      - "RateLimitPolicy":
-          - "Overview": kuadrant-operator/doc/overviews/rate-limiting.md
-          - "Reference": kuadrant-operator/doc/reference/ratelimitpolicy.md
-  - "How-to Guides":
-      - "Secure, connect and protect (Full Walkthrough)":
-          - "Kubernetes": kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-k8s.md
-          - "OpenShift": kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-openshift.md
-      - "DNS configuration":
-          - "Gateway DNS for Cluster Operators": kuadrant-operator/doc/user-guides/dns/gateway-dns.md
-          - "Configuring DNS Providers": dns-operator/docs/provider.md
-          - "Basic DNS configuration": kuadrant-operator/doc/user-guides/dns/basic-dns-configuration.md
-          - "DNS health checks": kuadrant-operator/doc/user-guides/dns/dnshealthchecks.md
-          - "Orphaned DNS Records": kuadrant-operator/doc/user-guides/dns/orphaned-dns-records.md
-          - "DNS excluding specific addresses": kuadrant-operator/doc/user-guides/dns/dns-excluding-specific-addresses.md
-      - "TLS configuration":
-          - "Gateway TLS for Cluster Operators": kuadrant-operator/doc/user-guides/tls/gateway-tls.md
-      - "Authentication & Authorization configuration":
-          - "Authentication":
-              - "AuthPolicy for Application Developers and Platform Engineers": kuadrant-operator/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
-              - "Authentication with Kubernetes tokens (TokenReview API)": authorino/docs/user-guides/kubernetes-tokenreview.md
-              - "Authentication with API keys": authorino/docs/user-guides/api-key-authentication.md
-              - "Authentication with X.509 certificates and mTLS": authorino/docs/user-guides/mtls-authentication.md
-              - "Authentication with HTTP 'Basic'": authorino/docs/user-guides/http-basic-authentication.md
-              - "Edge Authentication Architecture (EAA)": authorino/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
-              - "OIDC":
-                  - "OpenID Connect Discovery and authentication with JWTs": authorino/docs/user-guides/oidc-jwt-authentication.md
-                  - "OpenID Connect UserInfo": authorino/docs/user-guides/oidc-user-info.md
-                  - "OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak": authorino/docs/user-guides/oidc-rbac.md
-          - "Authorization":
-              - "Passing credentials (`Authorization` header, cookie headers and others)": authorino/docs/user-guides/passing-credentials.md
-              - "Resource-level authorization with User-Managed Access (UMA) resource registry": authorino/docs/user-guides/resource-level-authorization-uma.md
-              - "Authorization with Keycloak Authorization Services": authorino/docs/user-guides/keycloak-authorization-services.md
-              - "Simple pattern-matching authorization policies": authorino/docs/user-guides/json-pattern-matching-authorization.md
-              - "Kubernetes RBAC for service authorization (SubjectAccessReview API)": authorino/docs/user-guides/kubernetes-subjectaccessreview.md
-              - "Setting up Kuadrant authorization service as a Validating Webhook": authorino/docs/user-guides/validating-webhook.md
-              - "OPA Rego":
-                  - "Open Policy Agent (OPA) Rego policies": authorino/docs/user-guides/opa-authorization.md
-              - "Envoy":
-                  - "Emitting Envoy Dynamic Metadata": authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
-                  - "Reusing Envoy built-in authentication filter result": authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
-          - "Authorization Infrastructure and Management":
-              - "Anonymous access": authorino/docs/user-guides/anonymous-access.md
-              - "Token normalization": authorino/docs/user-guides/token-normalization.md
-              - "Fetching auth metadata from external sources": authorino/docs/user-guides/external-metadata.md
-              - "Integration with Authzed/SpiceDB": authorino/docs/user-guides/authzed.md
-              - "Injecting data in the request": authorino/docs/user-guides/injecting-data.md
-              - "Redirecting to a login page": authorino/docs/user-guides/deny-with-redirect-to-login.md
-              - "Caching": authorino/docs/user-guides/caching.md
-              - "OAuth 2.0 token introspection (RFC 7662)": authorino/docs/user-guides/oauth2-token-introspection.md
-      - "Rate Limiting configuration":
-          - "RateLimitPolicy for Platform Engineers": kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
-          - "Authenticated Rate Limiting for Application Developers": kuadrant-operator/doc/user-guides/authenticated-rl-for-app.md
-          - "Authenticated Rate Limiting with JWTs and Kubernetes RBAC": kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
-      - "Observability configuration":
-          - "Metrics": kuadrant-operator/doc/observability/metrics.md
-          - "Dashboards and Alerts": kuadrant-operator/doc/observability/examples.md
-          - "Tracing": kuadrant-operator/doc/observability/tracing.md
-          - "Authentication and Authorization": authorino/docs/user-guides/observability.md
-  - "Experimental":
-      - "API Quickstart": "api-quickstart/README.md"
-  - "Proposals":
-      - "Request For Comments (RFC)":
+  - 'Introduction':
+      - 'Overview': index.md
+      - 'Architecture': architecture/docs/design/architectural-overview-v1.md
+  - 'Getting Started':
+      - 'Single-Cluster': getting-started-single-cluster.md
+      - 'Multi-Cluster': getting-started-multi-cluster.md
+  - 'Installation':
+      - 'Kubernetes': kuadrant-operator/doc/install/install-kubernetes.md
+      - 'OpenShift': kuadrant-operator/doc/install/install-openshift.md
+      - 'From Source': kuadrant-operator/doc/install/install-make.md
+  - 'Concepts and APIs':
+      - 'DNSPolicy':
+          - 'Overview': kuadrant-operator/doc/overviews/dns.md
+          - 'Reference': kuadrant-operator/doc/reference/dnspolicy.md
+      - 'TLSPolicy':
+          - 'Overview': kuadrant-operator/doc/overviews/tls.md
+          - 'Reference': kuadrant-operator/doc/reference/tlspolicy.md
+      - 'AuthPolicy':
+          - 'Overview': kuadrant-operator/doc/overviews/auth.md
+          - 'Reference': kuadrant-operator/doc/reference/authpolicy.md
+      - 'RateLimitPolicy':
+          - 'Overview': kuadrant-operator/doc/overviews/rate-limiting.md
+          - 'Reference': kuadrant-operator/doc/reference/ratelimitpolicy.md
+  - 'How-to Guides':
+      - 'Secure, connect and protect (Full Walkthrough)':
+          - 'Kubernetes': kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-k8s.md
+          - 'OpenShift': kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-openshift.md
+      - 'DNS configuration':
+          - 'Gateway DNS for Cluster Operators': kuadrant-operator/doc/user-guides/dns/gateway-dns.md
+          - 'Configuring DNS Providers': dns-operator/docs/provider.md
+          - 'Basic DNS configuration': kuadrant-operator/doc/user-guides/dns/basic-dns-configuration.md
+          - 'DNS health checks': kuadrant-operator/doc/user-guides/dns/dnshealthchecks.md
+          - 'Orphaned DNS Records': kuadrant-operator/doc/user-guides/dns/orphaned-dns-records.md
+          - 'DNS excluding specific addresses': kuadrant-operator/doc/user-guides/dns/dns-excluding-specific-addresses.md
+      - 'TLS configuration':
+          - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/tls/gateway-tls.md
+      - 'Authentication & Authorization configuration':
+          - 'Authentication':
+              - 'AuthPolicy for Application Developers and Platform Engineers': kuadrant-operator/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+              - 'Authentication with Kubernetes tokens (TokenReview API)': authorino/docs/user-guides/kubernetes-tokenreview.md
+              - 'Authentication with API keys': authorino/docs/user-guides/api-key-authentication.md
+              - 'Authentication with X.509 certificates and mTLS': authorino/docs/user-guides/mtls-authentication.md
+              - 'Authentication with HTTP "Basic"': authorino/docs/user-guides/http-basic-authentication.md
+              - 'Edge Authentication Architecture (EAA)': authorino/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
+              - 'OIDC':
+                  - 'OpenID Connect Discovery and authentication with JWTs': authorino/docs/user-guides/oidc-jwt-authentication.md
+                  - 'OpenID Connect UserInfo': authorino/docs/user-guides/oidc-user-info.md
+                  - 'OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak': authorino/docs/user-guides/oidc-rbac.md
+          - 'Authorization':
+              - 'Passing credentials (`Authorization` header, cookie headers and others)': authorino/docs/user-guides/passing-credentials.md
+              - 'Resource-level authorization with User-Managed Access (UMA) resource registry': authorino/docs/user-guides/resource-level-authorization-uma.md
+              - 'Authorization with Keycloak Authorization Services': authorino/docs/user-guides/keycloak-authorization-services.md
+              - 'Simple pattern-matching authorization policies': authorino/docs/user-guides/json-pattern-matching-authorization.md
+              - 'Kubernetes RBAC for service authorization (SubjectAccessReview API)': authorino/docs/user-guides/kubernetes-subjectaccessreview.md
+              - 'Setting up Kuadrant authorization service as a Validating Webhook': authorino/docs/user-guides/validating-webhook.md
+              - 'OPA Rego':
+                  - 'Open Policy Agent (OPA) Rego policies': authorino/docs/user-guides/opa-authorization.md
+              - 'Envoy':
+                  - 'Emitting Envoy Dynamic Metadata': authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+                  - 'Reusing Envoy built-in authentication filter result': authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
+          - 'Authorization Infrastructure and Management':
+              - 'Anonymous access': authorino/docs/user-guides/anonymous-access.md
+              - 'Token normalization': authorino/docs/user-guides/token-normalization.md
+              - 'Fetching auth metadata from external sources': authorino/docs/user-guides/external-metadata.md
+              - 'Integration with Authzed/SpiceDB': authorino/docs/user-guides/authzed.md
+              - 'Injecting data in the request': authorino/docs/user-guides/injecting-data.md
+              - 'Redirecting to a login page': authorino/docs/user-guides/deny-with-redirect-to-login.md
+              - 'Caching': authorino/docs/user-guides/caching.md
+              - 'OAuth 2.0 token introspection (RFC 7662)': authorino/docs/user-guides/oauth2-token-introspection.md
+      - 'Rate Limiting configuration':
+          - 'RateLimitPolicy for Platform Engineers': kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
+          - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/authenticated-rl-for-app.md
+          - 'Authenticated Rate Limiting with JWTs and Kubernetes RBAC': kuadrant-operator/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+      - 'Observability configuration':
+          - 'Metrics': kuadrant-operator/doc/observability/metrics.md
+          - 'Dashboards and Alerts': kuadrant-operator/doc/observability/examples.md
+          - 'Tracing': kuadrant-operator/doc/observability/tracing.md
+          - 'Authentication and Authorization': authorino/docs/user-guides/observability.md
+  - 'Experimental':
+      - 'API Quickstart': 'api-quickstart/README.md'
+  - 'Proposals':
+      - 'Request For Comments (RFC)':
           - 'RFC 0001: RateLimitPolicy API "v2"': architecture/rfcs/0001-rlp-v2.md
-          - "RFC 0002: Well-known Attributes": architecture/rfcs/0002-well-known-attributes.md
-          - "RFC 0003: DNSPolicy": architecture/rfcs/0003-dns-policy.md
-          - "RFC 0004: Policy Status": architecture/rfcs/0004-policy-status.md
-          - "RFC 0005: Single Cluster DNSPolicy": architecture/rfcs/0005-single-cluster-dnspolicy.md
-          - "RFC 0006: Configuration of Kuadrant Sub Components": architecture/rfcs/0006-kuadrant_sub_components_configurations.md
-          - "RFC 0007: Policy Sync": architecture/rfcs/0007-policy-sync-v1.md
-          - "RFC 0008: Kuadrant Release Process": architecture/rfcs/0008-kuadrant-release-process.md
-          - "RFC 0009: Defaults & Overrides": architecture/rfcs/0009-defaults-and-overrides.md
-          - "RFC 0010: Gateway API Metrics Exporter": architecture/rfcs/0010-gateway-api-metrics-exporter.md
-          - "RFC 0011: Policy Machinery for reconciliation": architecture/rfcs/0011-policy-machinery.md
-  - "Components":
-      - "Kuadrant Operator": https://github.com/kuadrant/docs.kuadrant.io
-      - "Authorino": https://github.com/kuadrant/docs.kuadrant.io
-      - "Limitador": https://github.com/kuadrant/docs.kuadrant.io
-      - "kuadrantctl": https://github.com/kuadrant/docs.kuadrant.io
+          - 'RFC 0002: Well-known Attributes': architecture/rfcs/0002-well-known-attributes.md
+          - 'RFC 0003: DNSPolicy': architecture/rfcs/0003-dns-policy.md
+          - 'RFC 0004: Policy Status': architecture/rfcs/0004-policy-status.md
+          - 'RFC 0005: Single Cluster DNSPolicy': architecture/rfcs/0005-single-cluster-dnspolicy.md
+          - 'RFC 0006: Configuration of Kuadrant Sub Components': architecture/rfcs/0006-kuadrant_sub_components_configurations.md
+          - 'RFC 0007: Policy Sync': architecture/rfcs/0007-policy-sync-v1.md
+          - 'RFC 0008: Kuadrant Release Process': architecture/rfcs/0008-kuadrant-release-process.md
+          - 'RFC 0009: Defaults & Overrides': architecture/rfcs/0009-defaults-and-overrides.md
+          - 'RFC 0010: Gateway API Metrics Exporter': architecture/rfcs/0010-gateway-api-metrics-exporter.md
+          - 'RFC 0011: Policy Machinery for reconciliation': architecture/rfcs/0011-policy-machinery.md
+  - 'Components':
+      - 'Kuadrant Operator': https://github.com/kuadrant/docs.kuadrant.io
+      - 'Authorino': https://github.com/kuadrant/docs.kuadrant.io
+      - 'Limitador': https://github.com/kuadrant/docs.kuadrant.io
+      - 'kuadrantctl': https://github.com/kuadrant/docs.kuadrant.io
 


### PR DESCRIPTION
Changed the website directories to make them more user-friendly and organised. 
- Removed the duplication of the readme of the components to links of the readme themselves in Git Hub. 
- Added a Introduction directory for overview and architecture
- Added authorization, authentication and a "Authorization Infrastructure and Management heading for the auth how to to make it easier to read
