### PR TITLE
refactor: move authorino specfic guides to under Authorino User Guides

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,31 +145,6 @@ nav:
           - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/gateway-tls.md
       - 'Authentication & Authorization':
           - 'AuthPolicy for Application Developers and Platform Engineers': kuadrant-operator/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
-          - 'Authentication with Kubernetes tokens (TokenReview API)': authorino/docs/user-guides/kubernetes-tokenreview.md
-          - 'Authentication with API keys': authorino/docs/user-guides/api-key-authentication.md
-          - 'Authentication with X.509 certificates and mTLS': authorino/docs/user-guides/mtls-authentication.md
-          - 'OpenID Connect Discovery and authentication with JWTs': authorino/docs/user-guides/oidc-jwt-authentication.md
-          - 'OAuth 2.0 token introspection (RFC 7662)': authorino/docs/user-guides/oauth2-token-introspection.md
-          - 'Passing credentials (`Authorization` header, cookie headers and others)': authorino/docs/user-guides/passing-credentials.md
-          - 'HTTP "Basic" Authentication (RFC 7235)': authorino/docs/user-guides/http-basic-authentication.md
-          - 'Anonymous access': authorino/docs/user-guides/anonymous-access.md
-          - 'Token normalization': authorino/docs/user-guides/token-normalization.md
-          - 'Edge Authentication Architecture (EAA)': authorino/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
-          - 'Fetching auth metadata from external sources': authorino/docs/user-guides/external-metadata.md
-          - 'OpenID Connect UserInfo': authorino/docs/user-guides/oidc-user-info.md
-          - 'Resource-level authorization with User-Managed Access (UMA) resource registry': authorino/docs/user-guides/resource-level-authorization-uma.md
-          - 'Simple pattern-matching authorization policies': authorino/docs/user-guides/json-pattern-matching-authorization.md
-          - 'OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak': authorino/docs/user-guides/oidc-rbac.md
-          - 'Open Policy Agent (OPA) Rego policies': authorino/docs/user-guides/opa-authorization.md
-          - 'Kubernetes RBAC for service authorization (SubjectAccessReview API)': authorino/docs/user-guides/kubernetes-subjectaccessreview.md
-          - 'Authorization with Keycloak Authorization Services': authorino/docs/user-guides/keycloak-authorization-services.md
-          - 'Integration with Authzed/SpiceDB': authorino/docs/user-guides/authzed.md
-          - 'Injecting data in the request': authorino/docs/user-guides/injecting-data.md
-          - 'Emitting Envoy Dynamic Metadata': authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
-          - 'Redirecting to a login page': authorino/docs/user-guides/deny-with-redirect-to-login.md
-          - 'Reusing Envoy built-in authentication filter result': authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
-          - 'Setting up Kuadrant authorization service as a Validating Webhook': authorino/docs/user-guides/validating-webhook.md
-          - 'Caching': authorino/docs/user-guides/caching.md
       - 'Rate Limiting':
           - 'RateLimitPolicy for Platform Engineers': kuadrant-operator/doc/user-guides/gateway-rl-for-cluster-operators.md
           - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/authenticated-rl-for-app-developers.md
@@ -204,6 +179,32 @@ nav:
           - 'Authorino Operator': authorino-operator/README.md
           - 'Getting Started': authorino/docs/getting-started.md
           - 'Hello World': authorino/docs/user-guides/hello-world.md
+          - 'User Guides':
+            - 'Authentication with Kubernetes tokens (TokenReview API)': authorino/docs/user-guides/kubernetes-tokenreview.md
+            - 'Authentication with API keys': authorino/docs/user-guides/api-key-authentication.md
+            - 'Authentication with X.509 certificates and mTLS': authorino/docs/user-guides/mtls-authentication.md
+            - 'OpenID Connect Discovery and authentication with JWTs': authorino/docs/user-guides/oidc-jwt-authentication.md
+            - 'OAuth 2.0 token introspection (RFC 7662)': authorino/docs/user-guides/oauth2-token-introspection.md
+            - 'Passing credentials (`Authorization` header, cookie headers and others)': authorino/docs/user-guides/passing-credentials.md
+            - 'HTTP "Basic" Authentication (RFC 7235)': authorino/docs/user-guides/http-basic-authentication.md
+            - 'Anonymous access': authorino/docs/user-guides/anonymous-access.md
+            - 'Token normalization': authorino/docs/user-guides/token-normalization.md
+            - 'Edge Authentication Architecture (EAA)': authorino/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
+            - 'Fetching auth metadata from external sources': authorino/docs/user-guides/external-metadata.md
+            - 'OpenID Connect UserInfo': authorino/docs/user-guides/oidc-user-info.md
+            - 'Resource-level authorization with User-Managed Access (UMA) resource registry': authorino/docs/user-guides/resource-level-authorization-uma.md
+            - 'Simple pattern-matching authorization policies': authorino/docs/user-guides/json-pattern-matching-authorization.md
+            - 'OpenID Connect (OIDC) and Role-Based Access Control (RBAC) with Keycloak': authorino/docs/user-guides/oidc-rbac.md
+            - 'Open Policy Agent (OPA) Rego policies': authorino/docs/user-guides/opa-authorization.md
+            - 'Kubernetes RBAC for service authorization (SubjectAccessReview API)': authorino/docs/user-guides/kubernetes-subjectaccessreview.md
+            - 'Authorization with Keycloak Authorization Services': authorino/docs/user-guides/keycloak-authorization-services.md
+            - 'Integration with Authzed/SpiceDB': authorino/docs/user-guides/authzed.md
+            - 'Injecting data in the request': authorino/docs/user-guides/injecting-data.md
+            - 'Emitting Envoy Dynamic Metadata': authorino/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+            - 'Redirecting to a login page': authorino/docs/user-guides/deny-with-redirect-to-login.md
+            - 'Reusing Envoy built-in authentication filter result': authorino/docs/user-guides/envoy-jwt-authn-and-authorino.md
+            - 'Setting up Kuadrant authorization service as a Validating Webhook': authorino/docs/user-guides/validating-webhook.md
+            - 'Caching': authorino/docs/user-guides/caching.md
           - 'Architecture': authorino/docs/architecture.md
           - 'Reference': authorino/docs/features.md
           - 'Advanced features':


### PR DESCRIPTION
# Description
Part of https://github.com/Kuadrant/docs.kuadrant.io/issues/25

Move Authorino specific user guides mentioning `AuthConfig` to under Authorino -> User Guides instead since there'll probably be user confusion with `AuthPolicy`

We'll create some `AuthPolicy` specific guides from the `Authorino` guides that will be used for Kuadrant Operator as part of https://github.com/Kuadrant/docs.kuadrant.io/issues/25