### PR TITLE
DNS guides nav update

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,9 @@ nav:
       - 'DNS configuration':
           - 'Configuring a DNS Provider': dns-operator/docs/provider.md
           - 'Gateway DNS for ingress Gateway': kuadrant-operator/doc/user-guides/dns/gateway-dns.md
+          - 'Basic DNS': kuadrant-operator/doc/user-guides/dns/basic-dns-configuration.md
+          - 'DNS Load Balancing': kuadrant-operator/doc/user-guides/dns/load-balanced-dns.md
+          - 'Health Checks': kuadrant-operator/doc/user-guides/dns/dnshealthchecks.md
       - 'TLS configuration':
           - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/tls/gateway-tls.md
       - 'mTLS Configuration': kuadrant-operator/doc/install/mtls-configuration.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,8 +125,6 @@ nav:
       - 'DNSPolicy':
           - 'Overview': kuadrant-operator/doc/overviews/dns.md
           - 'Reference': kuadrant-operator/doc/reference/dnspolicy.md
-          - 'Gateway DNS for ingress Gateway': kuadrant-operator/doc/user-guides/dns/gateway-dns.md
-          - 'Configuring DNS Providers': dns-operator/docs/provider.md
       - 'TLSPolicy':
           - 'Overview': kuadrant-operator/doc/overviews/tls.md
           - 'Reference': kuadrant-operator/doc/reference/tlspolicy.md
@@ -140,7 +138,8 @@ nav:
       - 'Secure, connect and protect - Kubernetes': kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-k8s.md
       - 'Secure, connect and protect - OpenShift': kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-openshift.md
       - 'DNS configuration':
-          - 'DNS Providers': dns-operator/docs/provider.md
+          - 'Configuring a DNS Provider': dns-operator/docs/provider.md
+          - 'Gateway DNS for ingress Gateway': kuadrant-operator/doc/user-guides/dns/gateway-dns.md
       - 'TLS configuration':
           - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/tls/gateway-tls.md
       - 'mTLS Configuration': kuadrant-operator/doc/install/mtls-configuration.md


### PR DESCRIPTION
Moves 2 dns guides out of the reference section of the docs (see before/after screenshots).
1 of the guides was already in the guides section as well (so in 2 places at once), which was confusing if you reached it through the reference section as the side nav would change to the guides area.

I changed the order of the guides to what I thought made more sense as well. The guide for configuring a dns provider is above the guide for configuring the gateway

I also added in a few guides that landed on the v1.0.x branch in https://github.com/Kuadrant/docs.kuadrant.io/commit/a629b43646f5031590034c495e13017d0ec56bfc#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R144, but not on main.

before
![image](https://github.com/user-attachments/assets/e1c3f72f-8085-4531-8541-310cfdf40e80)

after
![image](https://github.com/user-attachments/assets/a3b4b36d-00cb-4933-be09-32eea46c0d7e)

![image](https://github.com/user-attachments/assets/3e3f5797-9e35-4f52-a49a-0a7476874000)

