### PR TITLE
Move DNS Operator component doc to top level components

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -229,8 +229,8 @@ nav:
               - 'Rate limit headers': limitador-operator/doc/rate-limit-headers.md
               - "Developer's Guide": limitador-operator/doc/development.md
               - limitador-operator/doc/logging.md
-          - 'DNS Operator':
-              - 'Overview': dns-operator/README.md
+      - 'DNS Operator':
+          - 'Overview': dns-operator/README.md
       - 'kuadrantctl':
           - 'Getting Started': kuadrantctl/README.md
           - 'Generating Gateway API HTTPRoutes': kuadrantctl/doc/generate-gateway-api-httproute.md


### PR DESCRIPTION
Moved out of Limitador component section to top level component

before
![image](https://github.com/user-attachments/assets/1de1a8ac-50da-41f8-8128-9015046f50a6)

after
![image](https://github.com/user-attachments/assets/4e0322f6-fe70-42f3-9231-2f5369a447b7)
