### PR TITLE
Remove experimental API Quickstart

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,11 +96,6 @@ plugins:
           imports:
             - /rfcs/*
             - /docs/*
-        - name: api-quickstart
-          import_url: 'https://github.com/kuadrant/api-quickstart?edit_uri=/blob/main/&branch=main'
-          imports:
-            - /README.md
-            - /images/*
         - name: kuadrantctl
           import_url: 'https://github.com/kuadrant/kuadrantctl?edit_uri=/blob/main/&branch=main'
           imports:
@@ -157,8 +152,6 @@ nav:
           - 'Dashboards and Alerts': kuadrant-operator/doc/observability/examples.md
           - 'Tracing': kuadrant-operator/doc/observability/tracing.md
           - 'Authentication and Authorization': authorino/docs/user-guides/observability.md
-  - 'Experimental':
-      - 'API Quickstart': 'api-quickstart/README.md'
   - 'Proposals':
       - 'Request For Comments (RFC)':
           - 'RFC 0001: RateLimitPolicy API "v2"': architecture/rfcs/0001-rlp-v2.md


### PR DESCRIPTION
The quickstart has served its purpose at an earlier stage of the kuadrant project, but is not been progressed passed the experimental stage.
It references older versions of the APIs that are not compatible with v1.
Let's remove it.
