### PR TITLE
Temp fix for k8s install doc removal

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,8 +114,8 @@ nav:
       - 'Multi-Cluster': getting-started-multi-cluster.md
   - 'Architecture': architecture/docs/design/architectural-overview-v1.md
   - 'Installation':
-      - 'Kubernetes': kuadrant-operator/doc/install/install-kubernetes.md
-      - 'OpenShift': kuadrant-operator/doc/install/install-openshift.md
+      - 'Helm': https://artifacthub.io/packages/helm/kuadrant/kuadrant-operator
+      - 'OLM on OpenShift': kuadrant-operator/doc/install/install-openshift.md
   - 'Concepts and APIs':
       - 'DNSPolicy':
           - 'Overview': kuadrant-operator/doc/overviews/dns.md


### PR DESCRIPTION
Since the [removal](https://github.com/Kuadrant/kuadrant-operator/pull/1091) of the (out of date) install on k8s doc, we should link to something.
The steps for the helm package on artifacthub work and should suffice as a stopgap for now.
Also, renaming the Openshift install guide to 'OLM on OpenShift' to show it's a different installation mechanism than Helm.
In future, the OLM guide should be reworked for both k8s & OpenShift use.