### PR TITLE
Move all tutorial docs into new Tutorials section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,25 +124,23 @@ nav:
       - 'AuthPolicy': kuadrant-operator/doc/reference/authpolicy.md
       - 'RateLimitPolicy': kuadrant-operator/doc/reference/ratelimitpolicy.md   
       - 'Kuadrant': kuadrant-operator/doc/reference/kuadrant.md         
-  - 'How-to Guides':
+  - 'Tutorials':
       - 'Secure, connect and protect': kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect.md
+      - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/tls/gateway-tls.md
+      - 'Enforcing authentication & authorization with Kuadrant AuthPolicy': kuadrant-operator/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+      - 'Gateway Rate Limiting for Cluster Operators': kuadrant-operator/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
+      - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
+      - 'Authenticated Rate Limiting with JWTs and Kubernetes RBAC': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
+      - 'Gateway Rate Limiting': kuadrant-operator/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
+      - 'Multi authenticated Rate Limiting for an Application': kuadrant-operator/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
+  - 'Guides':
       - 'DNS configuration':
           - 'Configuring a DNS Provider': dns-operator/docs/provider.md
           - 'Gateway DNS for ingress Gateway': kuadrant-operator/doc/user-guides/dns/gateway-dns.md
           - 'Basic DNS': kuadrant-operator/doc/user-guides/dns/basic-dns-configuration.md
           - 'DNS Load Balancing': kuadrant-operator/doc/user-guides/dns/load-balanced-dns.md
           - 'Health Checks': kuadrant-operator/doc/user-guides/dns/dnshealthchecks.md
-      - 'TLS configuration':
-          - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/tls/gateway-tls.md
       - 'mTLS Configuration': kuadrant-operator/doc/install/mtls-configuration.md
-      - 'Authentication & Authorization':
-          - 'AuthPolicy for Application Developers and Platform Engineers': kuadrant-operator/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
-      - 'Rate Limiting':
-          - 'RateLimitPolicy for Platform Engineers': kuadrant-operator/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
-          - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
-          - 'Authenticated Rate Limiting with JWTs and Kubernetes RBAC': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
-          - 'Authenticated Rate Limit Policies for different listeners in an ingress gateway': kuadrant-operator/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
-          - 'Authenticated Rate Limit Policies for the same HTTPRoute rule': kuadrant-operator/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
       - 'Observability':
           - 'Metrics': kuadrant-operator/doc/observability/metrics.md
           - 'Dashboards and Alerts': kuadrant-operator/doc/observability/examples.md


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1097

This PR splits out the 'How-to Guides' section into 'Tutorials' and 'Guides'.
Tutorials have been identified, as per diataxis compass (see https://github.com/Kuadrant/kuadrant-operator/issues/1097#issuecomment-2583319044), and moved to a new 'Tutorials' nav section, while the remaining content has been left in the (now renamed) 'Guides' nav section.

The content has not been changed in this PR.
Some nav titles have been updated to match the title in the doc.
