### PR TITLE
Move observability reference material

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,12 +118,15 @@ nav:
       - 'TLSPolicy': kuadrant-operator/doc/overviews/tls.md
       - 'AuthPolicy': kuadrant-operator/doc/overviews/auth.md
       - 'RateLimitPolicy': kuadrant-operator/doc/overviews/rate-limiting.md
-  - 'APIs':
+  - 'APIs & Reference':
       - 'DNSPolicy': kuadrant-operator/doc/reference/dnspolicy.md
       - 'TLSPolicy': kuadrant-operator/doc/reference/tlspolicy.md
       - 'AuthPolicy': kuadrant-operator/doc/reference/authpolicy.md
       - 'RateLimitPolicy': kuadrant-operator/doc/reference/ratelimitpolicy.md   
       - 'Kuadrant': kuadrant-operator/doc/reference/kuadrant.md         
+      - 'Observability':
+          - 'Metrics': kuadrant-operator/doc/observability/metrics.md
+          - 'Authentication and Authorization': authorino/docs/user-guides/observability.md
   - 'Tutorials':
       - 'Secure, connect and protect': kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect.md
       - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/tls/gateway-tls.md
@@ -142,7 +145,5 @@ nav:
           - 'Health Checks': kuadrant-operator/doc/user-guides/dns/dnshealthchecks.md
       - 'mTLS Configuration': kuadrant-operator/doc/install/mtls-configuration.md
       - 'Observability':
-          - 'Metrics': kuadrant-operator/doc/observability/metrics.md
           - 'Dashboards and Alerts': kuadrant-operator/doc/observability/examples.md
           - 'Tracing': kuadrant-operator/doc/observability/tracing.md
-          - 'Authentication and Authorization': authorino/docs/user-guides/observability.md


### PR DESCRIPTION
This change moves 2 observability docs out of the 'Guides' nav section as they are moreso reference material.
The 'APIs' section is also renamed to 'APIs & Reference' to show that docs in that section are not just api docs (a type of reference material), but more broad than that, to accommodate the 'Metrics' doc specifically.
