### PR TITLE
Add redirects plugin & install/scp redirects

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,14 @@ plugins:
             - /README.md
             - /docs/*
             - /config/samples/*
+  - redirects:
+      redirect_maps:
+        'getting-started-single-cluster.md': 'getting-started.md'
+        'getting-started-multi-cluster.md': 'getting-started.md'
+        'kuadrant-operator/doc/install/install-kubernetes.md': 'getting-started.md'
+        'kuadrant-operator/doc/install/install-openshift.md': 'getting-started.md'
+        'kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-k8s.md': 'kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect.md'
+        'kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect-openshift.md': 'kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect.md'
 nav:
   - 'Overview': index.md
   - 'Getting Started': getting-started.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs==1.6.1
 mkdocs-material==9.5.44
 mike==2.1.3
 mdx-breakless-lists==1.0.1
+mkdocs-redirects==1.2.2


### PR DESCRIPTION
Related to #170,
though it doesn't aim to address that issue in a general way.

The changes here:
- add the [mkdocs-redirects](https://github.com/mkdocs/mkdocs-redirects) plugin
- add redirects for the getting started, install and "Secure, Connect & Protect" tutorials that have changed path since previous versions

For running locally, I believe a new build of the `quay.io/kuadrant/docs.kuadrant.io:latest` image will be needed with `pip install` having been run.
To run this locally until then, you'll need to prefix any existing commands with `pip install -r requirements.txt &&`

For example:

```bash
docker run \
  -v "$(pwd):/docs" \
  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
  -p 8000:8000 quay.io/kuadrant/docs.kuadrant.io:latest \
  "pip install -r requirements.txt && mkdocs serve -s -a 0.0.0.0:8000"
```

and 

```bash
docker run \
  -v "$(pwd):/docs" \
  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
  -p 8000:8000 quay.io/kuadrant/docs.kuadrant.io:latest \
  "pip install -r requirements.txt && mike serve -a 0.0.0.0:8000"
```

Note that because of the way running `mike serve` locally works (from your local copy of the gh-pages branch), the redirects won't work with that unless you do a deploy of this PR branch as the 'dev' version locally first, like this:

```bash
docker run \
  -v "$(pwd):/docs" \
  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
  -p 8000:8000 quay.io/kuadrant/docs.kuadrant.io:latest \
  "pip install -r requirements.txt && mike deploy dev"

```