### PR TITLE
Adding TokenRateLimitPolicy ref + tutorial

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,10 +69,12 @@ plugins:
           - /doc/overviews/dns.md
           - /doc/overviews/rate-limiting.md
           - /doc/overviews/tls.md
+          - /doc/overviews/token-rate-limiting.md
           - /doc/reference/authpolicy.md
           - /doc/reference/dnspolicy.md
           - /doc/reference/kuadrant.md
           - /doc/reference/ratelimitpolicy.md
+          - /doc/reference/tokenratelimitpolicy.md
           - /doc/reference/tlspolicy.md
           - /doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
           - /doc/user-guides/dns/basic-dns-configuration.md
@@ -82,6 +84,7 @@ plugins:
           - /doc/user-guides/full-walkthrough/secure-protect-connect.md
           - /doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
           - /doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
+          - /doc/user-guides/tokenratelimitpolicy/authenticated-token-ratelimiting-tutorial.md
           - /doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
           - /doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
           - /doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
@@ -158,15 +161,17 @@ nav:
       - 'Install with OLM': install-olm.md
   - 'Concepts':
       - 'Architecture': architecture/docs/design/architectural-overview-v1.md
-      - 'DNSPolicy': kuadrant-operator/doc/overviews/dns.md
-      - 'TLSPolicy': kuadrant-operator/doc/overviews/tls.md
       - 'AuthPolicy': kuadrant-operator/doc/overviews/auth.md
+      - 'DNSPolicy': kuadrant-operator/doc/overviews/dns.md
       - 'RateLimitPolicy': kuadrant-operator/doc/overviews/rate-limiting.md
+      - 'TLSPolicy': kuadrant-operator/doc/overviews/tls.md
+      - 'TokenRateLimitPolicy': kuadrant-operator/doc/overviews/token-rate-limiting.md
   - 'APIs & Reference':
-      - 'DNSPolicy': kuadrant-operator/doc/reference/dnspolicy.md
-      - 'TLSPolicy': kuadrant-operator/doc/reference/tlspolicy.md
       - 'AuthPolicy': kuadrant-operator/doc/reference/authpolicy.md
+      - 'DNSPolicy': kuadrant-operator/doc/reference/dnspolicy.md
       - 'RateLimitPolicy': kuadrant-operator/doc/reference/ratelimitpolicy.md   
+      - 'TLSPolicy': kuadrant-operator/doc/reference/tlspolicy.md
+      - 'TokenRateLimitPolicy': kuadrant-operator/doc/reference/tokenratelimitpolicy.md
       - 'Kuadrant': kuadrant-operator/doc/reference/kuadrant.md         
       - 'Observability':
           - 'Metrics': kuadrant-operator/doc/observability/metrics.md
@@ -180,6 +185,7 @@ nav:
       - 'Authenticated Rate Limiting with JWTs and Kubernetes RBAC': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
       - 'Gateway Rate Limiting': kuadrant-operator/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
       - 'Multi authenticated Rate Limiting for an Application': kuadrant-operator/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
+      - 'Authenticated Token Rate Limiting for Large Language Model APIs': kuadrant-operator/doc/user-guides/tokenratelimitpolicy/authenticated-token-ratelimiting-tutorial.md
   - 'Guides':
       - 'DNS configuration':
           - 'Configuring a DNS Provider': dns-operator/docs/provider.md


### PR DESCRIPTION
Adds reference docs and a tutorial for `TokenRateLimitPolicy`

part of:

https://github.com/Kuadrant/kuadrant-operator/issues/1344