### PR TITLE
readme updates for clarity, and an experimental claude command for minor releases

### DIFF
--- a/.claude/commands/minor-release.md
+++ b/.claude/commands/minor-release.md
@@ -1,0 +1,111 @@
+---
+description: Create a minor docs release (e.g., v1.3.x -> v1.4.x)
+---
+
+Perform a minor release of the Kuadrant documentation site. This creates a new versioned release branch and updates all multirepo import refs to point at the correct release branches/tags for each component.
+
+The user will provide the new version (e.g. "1.4.x") and the previous version to base from (e.g. "1.3.x"). If not provided, look at mkdocs.yml `extra.version.default` to determine the current latest, and increment the minor number.
+
+## Steps
+
+1. **Check prerequisites:**
+   - Verify `gh` CLI is installed and authenticated: `gh auth status`
+   - If not installed or not authenticated, stop and tell the user to install/authenticate first
+   - Check if `mkdocs` is available locally (e.g. in a venv). If not, note that docker/podman will be used instead via:
+     `docker run -v "$(pwd):/docs" -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" quay.io/kuadrant/docs.kuadrant.io:latest "<command>"`
+   - Set a variable to track which method to use (local or docker) for subsequent build/deploy steps
+
+2. **Sync with upstream:**
+   - `git fetch upstream`
+   - Ensure local `main` is up to date with `upstream/main`
+   - If behind: `git rebase upstream/main`
+
+3. **Determine the new version:**
+   - Read the current `extra.version.default` from `mkdocs.yml` on `main` to find the current latest (e.g. `1.3.x`)
+   - The new version increments the minor number (e.g. `1.4.x`)
+   - Confirm with the user before proceeding
+
+4. **Look up component release refs (using `gh` CLI):**
+   For each component in `mkdocs.yml` under `multirepo.nav_repos`, determine the correct git ref. The ref should match whatever branch or tag corresponds to the **latest GitHub release** for that component. Version numbers across components don't necessarily correlate -- e.g. Kuadrant v1.4 might use authorino v0.24.0 and dns-operator v0.16.0.
+
+   For each component (except `architecture` which is always `main`), look up the latest GitHub release:
+   Run: `gh api repos/kuadrant/{repo}/releases/latest --jq '.tag_name'`
+
+   Then check whether that release tag has a corresponding branch (some repos use release branches, others just tags):
+   Run: `gh api repos/kuadrant/{repo}/branches --paginate --jq '.[].name' | grep release`
+
+   Use the release branch if one exists for that version, otherwise use the tag directly.
+
+   Present the discovered refs to the user in a table and ask them to confirm or correct before proceeding. Format:
+
+   | Component | Latest release | Ref to use | Type |
+   |-|-|-|-|
+   | kuadrant-operator | v1.4.0 | release-v1.4 | branch |
+   | authorino | v0.24.0 | v0.24.0 | tag |
+   | dns-operator | v0.16.0 | v0.16.0 | tag |
+   | ... | ... | ... | ... |
+
+5. **Create the release branch:**
+   - `git checkout -b v{VERSION} main` (e.g. `v1.4.x`)
+
+6. **Update mkdocs.yml on the release branch:**
+   - For each component, update the `import_url` line to use the confirmed ref:
+     `https://github.com/kuadrant/{repo}?edit_uri=/blob/{ref}/&branch={ref}`
+   - Update `edit_uri` to match the release ref for repos that have release branches (e.g. kuadrant-operator).
+     For tag-only repos (e.g. authorino), the edit_uri can stay pointing at `main` since tags are read-only.
+   - Update the version default:
+     ```yaml
+     extra:
+       version:
+         provider: mike
+         default:
+           - {VERSION}
+           - latest
+     ```
+
+7. **Build and verify:**
+   - If mkdocs is available locally: `mkdocs build -s`
+   - If using docker: `docker run -v "$(pwd):/docs" quay.io/kuadrant/docs.kuadrant.io:latest "mkdocs build -s"`
+   - If it fails, diagnose and fix before continuing
+
+8. **Print a summary of commands for the user to run:**
+   After the build succeeds, print a copy-pasteable block of all remaining commands.
+   Use the local or docker variant depending on what was detected in step 1.
+
+   Local:
+   ```
+   # push the release branch to upstream (Kuadrant org)
+   git push upstream v{VERSION}
+
+   # deploy to gh-pages with the latest alias
+   mike deploy --update-aliases {VERSION} latest --push
+
+   # set as the default version
+   mike set-default {VERSION} --push
+
+   # switch back to main and update the default version
+   git checkout main
+   # (optionally update extra.version.default in mkdocs.yml on main to {VERSION})
+   ```
+
+   Docker:
+   ```
+   git push upstream v{VERSION}
+
+   docker run -v "$(pwd):/docs" -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
+     quay.io/kuadrant/docs.kuadrant.io:latest "mike deploy --update-aliases {VERSION} latest --push"
+
+   docker run -v "$(pwd):/docs" -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
+     quay.io/kuadrant/docs.kuadrant.io:latest "mike set-default {VERSION} --push"
+
+   git checkout main
+   ```
+
+   Only print the variant that matches the user's environment.
+
+Important notes:
+- This repo uses a fork workflow (origin = user's fork, upstream = Kuadrant org). Pushes go to upstream, not origin.
+- NEVER run `git push`, `mike deploy`, or `mike set-default` commands. Only print them as instructions for the user to copy and run themselves.
+- If a component ref can't be found, ask the user rather than guessing
+- Some newer components (developer-portal-controller, kuadrant-backstage-plugin, mcp-gateway) may not have release branches yet -- default to `main` and flag it
+- The build step is critical -- don't skip it, as missing imports will cause failures in strict mode

--- a/.claude/commands/minor-release.md
+++ b/.claude/commands/minor-release.md
@@ -78,10 +78,10 @@ The user will provide the new version (e.g. "1.4.x") and the previous version to
    git push upstream v{VERSION}
 
    # deploy to gh-pages with the latest alias
-   mike deploy --update-aliases {VERSION} latest --push
+   mike deploy --update-aliases {VERSION} latest --push --remote upstream
 
    # set as the default version
-   mike set-default {VERSION} --push
+   mike set-default {VERSION} --push --remote upstream
 
    # switch back to main and update the default version
    git checkout main
@@ -93,10 +93,10 @@ The user will provide the new version (e.g. "1.4.x") and the previous version to
    git push upstream v{VERSION}
 
    docker run -v "$(pwd):/docs" -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-     quay.io/kuadrant/docs.kuadrant.io:latest "mike deploy --update-aliases {VERSION} latest --push"
+     quay.io/kuadrant/docs.kuadrant.io:latest "mike deploy --update-aliases {VERSION} latest --push --remote upstream"
 
    docker run -v "$(pwd):/docs" -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-     quay.io/kuadrant/docs.kuadrant.io:latest "mike set-default {VERSION} --push"
+     quay.io/kuadrant/docs.kuadrant.io:latest "mike set-default {VERSION} --push --remote upstream"
 
    git checkout main
    ```

--- a/README.md
+++ b/README.md
@@ -2,17 +2,68 @@
 
 ## Overview
 
-This repository contains documentation for Kuadrant, built using MkDocs and the `mike` plugin for multi-versioning. You can run and build these docs using Docker/Podman or by installing MkDocs locally.
+This repository builds the documentation site for Kuadrant using MkDocs, Material theme, and the `mkdocs-multirepo-plugin`. Content is pulled from multiple Kuadrant repositories and published as a single site with multi-versioning via `mike`.
 
 ## Contributing
 
 See [./CONTRIBUTING.md](./CONTRIBUTING.md)
 
-## Using Docker/Podman
+## How versioning works
 
-### Running the Docs with Docker
+The site uses [mike](https://github.com/jimporter/mike) to maintain multiple documentation versions on the `gh-pages` branch. Each version is a self-contained snapshot.
 
-To run the docs using Docker, mount the current directory to the container and bind it to port `8000`:
+**Aliases:**
+
+- `latest` -- points to the most recent stable release (currently `1.3.x`)
+- `dev` -- built nightly from `main`, contains unreleased content
+
+**Branching model:**
+
+- `main` -- all multirepo `import_url` refs point to `branch=main`. Merges to `main` auto-deploy the `dev` version.
+- Release branches (e.g. `v1.3.x`) -- created for each stable release. The `import_url` refs are updated to point at specific release branches or tags for each component repo.
+
+**Component ref patterns per release:**
+
+Not all repos follow the same convention. When preparing a release branch, you need to look up the correct ref for each component:
+
+| Component | Ref style | Example (v1.3.x) |
+|-|-|-|
+| `kuadrant-operator` | Release branch | `release-v1.3` |
+| `authorino` | Tag | `v0.23.0` |
+| `dns-operator` | Tag or release branch | `v0.15.0` |
+| `architecture` | Always `main` | `main` |
+| `developer-portal-controller` | TBD (new) | `main` |
+| `kuadrant-backstage-plugin` | TBD (new) | `main` |
+| `mcp-gateway` | TBD (new) | `main` |
+
+## Running locally
+
+### Prerequisites
+
+Install [uv](https://github.com/astral-sh/uv) and [asciidoctor](https://asciidoctor.org/):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# macOS
+brew install asciidoctor
+
+# Linux
+gem install asciidoctor
+```
+
+### Setup and serve
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -r pyproject.toml
+mkdocs serve -s
+```
+
+Docs will be at [http://127.0.0.1:8000](http://127.0.0.1:8000).
+
+### Using Docker/Podman
 
 ```bash
 docker run \
@@ -23,356 +74,82 @@ docker run \
   "mkdocs serve -s -a 0.0.0.0:8000"
 ```
 
-This will serve the docs at [http://localhost:8000](http://localhost:8000).
-
----
-
-## Running Locally without Docker
-
-### Installing uv
-
-First, install `uv` (a fast Python package installer):
-
-```bash
-# Using curl
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-### Installing Dependencies
-
-Install the project dependencies using `uv`:
-
-```bash
-uv venv
-source .venv/bin/activate
-uv pip install -r pyproject.toml
-```
-
-You'll also need `asciidoctor` for AsciiDoc support:
-
-```bash
-# macOS
-brew install asciidoctor
-
-# Linux
-gem install asciidoctor
-```
-
-### Serving the Docs Locally
-
-To serve the docs locally, run:
-
-```bash
-mkdocs serve -s
-```
-
-You can then view the docs at [http://127.0.0.1:8000](http://127.0.0.1:8000) on your current branch.
-
-### AsciiDoc Support
-
-Both Markdown (`.md`) and AsciiDoc (`.adoc`) files are supported. AsciiDoc files are converted using [Asciidoctor](https://asciidoctor.org/) via the [mkdocs-asciidoctor-backend](https://github.com/aireilly/mkdocs-asciidoctor-backend) plugin.
-
-To add an AsciiDoc page:
-
-1. Create a `.adoc` file in `docs/`
-2. Add it to the `nav` section in `mkdocs.yml`
-
-Example AsciiDoc file:
-
-```asciidoc
-= Page Title
-
-== Section
-
-Some content with *bold* and _italic_ text.
-
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-----
-```
-
-See `docs/install-helm.adoc` for an example.
-
-### Running Multi-Versioned Docs
-
-If you’d like to test the multi-versioned documentation setup locally, use `mike`:
+### Multi-versioned docs (from gh-pages)
 
 ```bash
 mike serve
 ```
 
-Or, with Docker / Podman:
+This serves the built versions from the `gh-pages` branch, not your working tree. For day-to-day development, use `mkdocs serve -s`.
 
-```bash
-docker run \
-  -v "$(pwd):/docs" \
-  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
-  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-  -p 8000:8000 quay.io/kuadrant/docs.kuadrant.io:latest \
-  "mike serve -a 0.0.0.0:8000"
-```
+## AsciiDoc support
 
-This will serve the docs from the `gh-pages` branch with multi-versioning. For general development, use `mkdocs serve`.
+Both Markdown (`.md`) and AsciiDoc (`.adoc`) files are supported via the [mkdocs-asciidoctor-backend](https://github.com/aireilly/mkdocs-asciidoctor-backend) plugin.
 
----
-
-## Building the Docs
-
-For automated builds, see the GitHub Actions workflows in `.github/workflows/build.yaml` and `.github/workflows/manual-deploy.yaml`.
-
----
-
-## Using `mike` for Versioned Docs
-
-We use `mike` for managing multi-versioned docs. It works by adding new commits to the `gh-pages` branch each time you run `mike deploy`. Older versions remain available without modification. If needed, existing versions can be re-built.
-
-### Common `mike` Commands
-
-#### List releases
-
-Locally:
-
-```bash
-mike list
-```
-
-Docker / Podman:
-
-```bash
-docker run \
-  -v "$(pwd):/docs" \
-  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
-  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-  quay.io/kuadrant/docs.kuadrant.io:latest \
-  "mike list"
-```
-
-#### Deploy a new release with a custom title
-
-Locally:
-
-```bash
-mike deploy 1.0.x -t "1.0.x (latest stable)"
-```
-
-Docker / Podman:
-
-```bash
-docker run \
-  -v "$(pwd):/docs" \
-  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
-  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-  quay.io/kuadrant/docs.kuadrant.io:latest \
-  "mike deploy 1.0.x -t '1.0.x (latest stable)'"
-```
-
-#### Delete a release
-
-Locally:
-
-```bash
-mike delete 1.0.x
-```
-
-Docker / Podman:
-
-```bash
-docker run \
-  -v "$(pwd):/docs" \
-  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
-  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-  quay.io/kuadrant/docs.kuadrant.io:latest \
-  "mike delete 1.0.x"
-```
-
-#### Serve multi-versioned docs
-
-Locally:
-
-```bash
-mike serve -S
-```
-
-Docker / Podman:
-
-```bash
-docker run \
-  -v "$(pwd):/docs" \
-  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
-  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-  -p 8000:8000 quay.io/kuadrant/docs.kuadrant.io:latest \
-  "mike serve -a 0.0.0.0:8000"
-```
-
----
-
-## Mike Aliases
-
-We use two aliases with `mike`:
-
-- `latest`: Points to the latest stable release (e.g., `latest -> 1.0.x`)
-- `dev`: Points to `HEAD` of `main`, for unstable or pre-release documentation
-
----
+To add an AsciiDoc page, create a `.adoc` file in `docs/` and add it to the `nav` section in `mkdocs.yml`. See `docs/install-helm.adoc` for an example.
 
 ## Releases
 
-Development releases from `main` will deploy to `dev` as a fast channel. The `latest` alias points to the most recent stable release by default.
+### Creating a stable release
 
-Stable releases should be tagged (e.g., `git tag 0.6.1`) for clarity.
+1. Create a release branch from `main` (e.g. `git checkout -b v1.4.x`).
+2. Update `mkdocs.yml` on the release branch:
+   - Change each `import_url` to point at the correct release branch or tag for that component (see table above).
+   - Update the `edit_uri` to match the release ref where appropriate.
+3. Update the version default in `mkdocs.yml`:
+   ```yaml
+   extra:
+     version:
+       provider: mike
+       default:
+         - 1.4.x
+         - latest
+   ```
+4. Build and verify: `mkdocs build -s`
+5. Deploy with the `latest` alias:
+   ```bash
+   mike deploy --update-aliases 1.4.x latest --push
+   ```
+6. Set as default:
+   ```bash
+   mike set-default 1.4.x --push
+   ```
 
-### Creating a Stable Release
+### Re-deploying a version
 
-To mark a new release as stable, follow these steps:
+Use the GitHub Actions workflow: **Actions > Re-deploy via mike**. For the nightly `dev` build, this runs automatically at midnight UTC.
 
-> **Note:** This process is currently manual and will be automated soon.
+For manual re-deploys, specify the version and source branch in the workflow inputs.
 
-1. Create a release branch from `main` (e.g., `git checkout -b v1.0.x`).
-2. In the release branch (`v1.0.x`):
-    - Update `mkdocs.yml` to replace `branch=` references with specific tags for all components.
-    - Set the latest release as default in `mkdocs.yml`:
-      ```yaml
-      extra:
-        version:
-          provider: mike
-          default:
-            - 1.0.x
-            - latest
-      ```
-    - Update any other references for the new release, including `import_url` git refs and other version-specific settings.
-3. Deploy the release with the `latest` alias:
-
-Locally:
+### Common mike commands
 
 ```bash
-mike deploy --update-aliases 1.0.x latest --push
+mike list                                          # list deployed versions
+mike deploy 1.4.x -t "1.4.x" --push               # deploy a version
+mike deploy --update-aliases 1.4.x latest --push    # deploy with alias
+mike set-default 1.4.x --push                       # set default version
+mike delete 1.4.x --push                            # delete a version
 ```
 
-Docker / Podman:
+## CI/CD
+
+| Workflow | Trigger | What it does |
+|-|-|-|
+| `build.yaml` | PR, merge to `main` | Validates PRs with `mkdocs build -s`. On merge, deploys `dev` via mike. |
+| `mike-redeploy.yaml` | Nightly (midnight UTC), manual | Re-deploys a version. Nightly rebuilds `dev` from `main`. |
+
+## Building the Docker image
 
 ```bash
-docker run \
-  -v "$(pwd):/docs" \
-  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
-  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-  quay.io/kuadrant/docs.kuadrant.io:latest \
-  "mike deploy --update-aliases 1.0.x latest --push --allow-empty"
-```
-
-4. Set this release as the default version:
-
-Locally:
-
-```bash
-mike set-default 1.0.x --push
-```
-
-Docker / Podman:
-
-```bash
-docker run \
-  -v "$(pwd):/docs" \
-  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
-  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-  quay.io/kuadrant/docs.kuadrant.io:latest \
-  "mike set-default 1.0.x --push --allow-empty"
-```
-
-5. Tag the repo (e.g., `git tag 1.0.x && git push --tags <upstream-origin>`).
-
----
-
-## Re-Releasing Docs
-
-Re-releasing an existing version is generally not recommended but can be done if necessary.
-
-### Via GitHub Actions (Recommended)
-
-To re-release a version, go to `Actions > Re-deploy via mike` in GitHub and run the workflow with the desired version and source branch.
-
-For reference:
-
-| Workflow Source | Version to Deploy | Source Branch | Notes               |
-|-----------------|-------------------|---------------|---------------------|
-| main            | 0.10.0            | 0.10.0        | Latest Stable       |
-| main            | 0.8.0             | 0.8           |                     |
-| main            | dev               | main          | Development - Unstable |
-
-### Manual Re-release
-
-1. Fetch latest changes: `git fetch --all`
-2. Check out the release branch: `git checkout 0.7.x`
-3. Make necessary changes and re-deploy:
-
-Locally:
-
-```bash
-mike deploy 1.0.x -t "1.0.x" --push
-```
-
-Docker / Podman:
-
-```bash
-docker run \
-  -v "$(pwd):/docs" \
-  -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
-  -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
-  quay.io/kuadrant/docs.kuadrant.io:latest \
-  "mike deploy 1.0.x -t '1.0.x' --push"
-```
-
-4. If there’s a push error, reset to the latest `gh-pages` branch and try again.
-
----
-
-## Deploying
-
-This site deploys automatically via GitHub Pages on merge to `main`. To manually trigger a deployment, go to `Actions > ci > Run Workflow`:
-
-![Deploy](docs/assets/images/deploy.png)
-
-This workflow will build the documentation bundle and trigger a push to the `gh-pages` branch.
-
-
-## Building the Docker Image
-
-### Single Architecture
-
-```bash
+# single architecture
 docker build -t quay.io/kuadrant/docs.kuadrant.io:latest .
-docker push quay.io/kuadrant/docs.kuadrant.io:latest
-```
 
-### Multi-Architecture (amd64 + arm64)
-
-```bash
-# create and use buildx builder
+# multi-architecture (amd64 + arm64)
 docker buildx create --name multiarch --use
-
-# build and push for both architectures
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
   -t quay.io/kuadrant/docs.kuadrant.io:latest \
   --push .
 ```
 
-**Note:** requires Docker Buildx and authentication to quay.io (`docker login quay.io`)
-
-
-### Troubleshooting
-
-#### Errors with the docs.kuadrant.io container
-
-```bash
-error: failed to push branch gh-pages to origin:
-  /opt/app-root/src/.ssh/config: line 8: Bad configuration option: usekeychain
-  /opt/app-root/src/.ssh/config: terminating, 1 bad configuration options
-  fatal: Could not read from remote repository.
-
-  Please make sure you have the correct access rights
-  and the repository exists.
-```
-
-Remove the `usekeychain` option from your `~/.ssh/config` and try again.
+Requires Docker Buildx and authentication to quay.io.


### PR DESCRIPTION
Cleaned up a BUNCH of stuff in the README.md to make things clearer.

Added an experiemental `/minor-release` claude command for minor releases.

CC: @R-Lawton as I think you're doing the 1.4 docs release