### PR TITLE
fix: add missing auth doc imports to unbreak CI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ plugins:
           - /doc/observability/tracing.md
           - /examples/otel/README.md
           - /doc/overviews/auth.md
+          - /doc/overviews/auth-x509.md
           - /doc/overviews/dns.md
           - /doc/overviews/rate-limiting.md
           - /doc/overviews/tls.md
@@ -80,6 +81,8 @@ plugins:
           - /doc/reference/tokenratelimitpolicy.md
           - /doc/reference/tlspolicy.md
           - /doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+          - /doc/user-guides/auth/anonymous-access.md
+          - /doc/user-guides/auth/x509-client-certificate-authentication.md
           - /doc/user-guides/dns/basic-dns-configuration.md
           - /doc/user-guides/dns/core-dns.md
           - /doc/user-guides/dns/core-dns.png
@@ -246,6 +249,7 @@ nav:
   - 'Concepts':
       - 'Architecture': architecture/docs/design/architectural-overview-v1.md
       - 'AuthPolicy': kuadrant-operator/doc/overviews/auth.md
+      - 'X.509 Authentication': kuadrant-operator/doc/overviews/auth-x509.md
       - 'DNSPolicy': kuadrant-operator/doc/overviews/dns.md
       - 'RateLimitPolicy': kuadrant-operator/doc/overviews/rate-limiting.md
       - 'TLSPolicy': kuadrant-operator/doc/overviews/tls.md
@@ -272,6 +276,8 @@ nav:
       - 'Secure, connect and protect': kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect.md
       - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/tls/gateway-tls.md
       - 'Enforcing authentication & authorization with Kuadrant AuthPolicy': kuadrant-operator/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+      - 'Anonymous Access': kuadrant-operator/doc/user-guides/auth/anonymous-access.md
+      - 'X.509 Client Certificate Authentication': kuadrant-operator/doc/user-guides/auth/x509-client-certificate-authentication.md
       - 'Gateway Rate Limiting for Cluster Operators': kuadrant-operator/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
       - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
       - 'Authenticated Rate Limiting with JWTs and Kubernetes RBAC': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md


### PR DESCRIPTION
## Summary

- Add 3 missing imports referenced by `auth.md`: `auth-x509.md`, `anonymous-access.md`, `x509-client-certificate-authentication.md`
- Add corresponding nav entries under Concepts and Tutorials

Fixes the 5 warnings that break `mkdocs build -s` on main.