### PR TITLE
Add GRPCRoute user guide and fix x509 documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,10 @@ plugins:
           - /doc/reference/tlspolicy.md
           - /doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
           - /doc/user-guides/auth/anonymous-access.md
-          - /doc/user-guides/auth/x509-client-certificate-authentication.md
+          - /doc/user-guides/auth/x509-authentication.md
+          - /doc/user-guides/auth/x509-tier1-gateway-api-validation.md
+          - /doc/user-guides/auth/x509-tier2-provider-specific.md
+          - /doc/user-guides/auth/x509-tier3-header-only.md
           - /doc/user-guides/dns/basic-dns-configuration.md
           - /doc/user-guides/dns/core-dns.md
           - /doc/user-guides/dns/core-dns.png
@@ -93,6 +96,7 @@ plugins:
           - /doc/user-guides/full-walkthrough/secure-protect-connect.md
           - /doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
           - /doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
+          - /doc/user-guides/ratelimiting/authenticated-rl-for-app-developers-grpc-services.md
           - /doc/user-guides/tokenratelimitpolicy/authenticated-token-ratelimiting-tutorial.md
           - /doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
           - /doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
@@ -280,10 +284,15 @@ nav:
       - 'Gateway TLS for Cluster Operators': kuadrant-operator/doc/user-guides/tls/gateway-tls.md
       - 'Enforcing authentication & authorization with Kuadrant AuthPolicy': kuadrant-operator/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
       - 'Anonymous Access': kuadrant-operator/doc/user-guides/auth/anonymous-access.md
-      - 'X.509 Client Certificate Authentication': kuadrant-operator/doc/user-guides/auth/x509-client-certificate-authentication.md
+      - 'X.509 Client Certificate Authentication':
+          - 'Overview': kuadrant-operator/doc/user-guides/auth/x509-authentication.md
+          - 'Tier 1: Gateway API Validation': kuadrant-operator/doc/user-guides/auth/x509-tier1-gateway-api-validation.md
+          - 'Tier 2: Provider-Specific': kuadrant-operator/doc/user-guides/auth/x509-tier2-provider-specific.md
+          - 'Tier 3: Header-Only': kuadrant-operator/doc/user-guides/auth/x509-tier3-header-only.md
       - 'Gateway Rate Limiting for Cluster Operators': kuadrant-operator/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
       - 'Authenticated Rate Limiting for Application Developers': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
       - 'Authenticated Rate Limiting with JWTs and Kubernetes RBAC': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
+      - 'Authenticated Rate Limiting for gRPC Services': kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers-grpc-services.md
       - 'Gateway Rate Limiting': kuadrant-operator/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
       - 'Multi authenticated Rate Limiting for an Application': kuadrant-operator/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
       - 'Authenticated Token Rate Limiting for Large Language Model APIs': kuadrant-operator/doc/user-guides/tokenratelimitpolicy/authenticated-token-ratelimiting-tutorial.md


### PR DESCRIPTION
## Summary

Adds the new GRPCRoute user guide and fixes x509 authentication documentation structure.

### GRPCRoute Guide
- Import the `authenticated-rl-for-app-developers-grpc-services.md` guide from kuadrant-operator
- Add navigation entry in the Tutorials section

The guide demonstrates:
- Service-level rate limiting with CEL predicates
- Method-level overrides via GRPCRoute section targeting
- Per-method authentication with AuthPolicy

### X.509 Documentation Fix
Updates x509 authentication docs to the new tiered structure introduced in kuadrant-operator PR #1931:
- Replaced old `x509-client-certificate-authentication.md` with new tiered structure
- Added main overview: `x509-authentication.md`
- Added tier-specific guides: Tier 1 (Gateway API Validation), Tier 2 (Provider-Specific), Tier 3 (Header-Only)
- Organized navigation with nested structure under "X.509 Client Certificate Authentication"

This fixes CI build warnings caused by the old x509 guide referencing files that no longer exist.

## Test Plan

- [x] YAML syntax validated
- [x] Documentation builds successfully (`mkdocs build`)
- [x] GRPCRoute guide imported and rendered correctly
- [x] X.509 tier guides imported and rendered correctly
- [x] Navigation appears in site structure with proper nesting

Related to:
- kuadrant-operator PR https://github.com/Kuadrant/kuadrant-operator/pull/1939 (GRPCRoute support)
- kuadrant-operator PR https://github.com/Kuadrant/kuadrant-operator/pull/1931 (X.509 tiered guides)