### PR TITLE
ci: split build into required build check and optional link check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
           mike deploy --push dev -t "dev"
 
   build:
-    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +66,25 @@ jobs:
       - name: Install asciidoctor
         run: sudo gem install asciidoctor
       - run: mkdocs build -s
+  link-check:
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      - run: uv pip install --system -r pyproject.toml
+      - name: Install asciidoctor
+        run: sudo gem install asciidoctor
+      - run: mkdocs build -s -f mkdocs-link-check.yml
   required-checks:
     name: CI Required Checks
     # This check adds a list of checks to one job to simplify adding settings to the repo.

--- a/mkdocs-link-check.yml
+++ b/mkdocs-link-check.yml
@@ -1,0 +1,11 @@
+INHERIT: mkdocs.yml
+validation:
+  nav:
+    not_found: warn
+  links:
+    not_found: warn
+    anchors: warn
+    # absolute links (e.g. /latest/getting-started) work on the live site but
+    # can't be verified at build time — keep at info to avoid false positives
+    absolute_links: info
+    unrecognized_links: info

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,14 @@ extra_css:
   - assets/stylesheets/extra.css
 watch:
   - overrides
+validation:
+  nav:
+    not_found: info
+  links:
+    not_found: info
+    anchors: info
+    absolute_links: info
+    unrecognized_links: info
 markdown_extensions:
   - mdx_breakless_lists
   - pymdownx.superfences:


### PR DESCRIPTION
## Summary

- Split CI into two jobs: **build** (required) and **link-check** (optional)
- Add `validation` config to `mkdocs.yml` with all link checks at `info` level
- Add `mkdocs-link-check.yml` overlay for the link-check job

## Problem

When upstream repos restructure docs, the strict-mode build fails on every PR — blocking all docs work. Additionally, broken links across imported repos were invisible because MkDocs defaults most link checks to `info` level.

## Solution

### Two CI jobs

| Job | Config | Required | Purpose |
|-----|--------|----------|---------|
| `build` | `mkdocs.yml` (links at `info`) | Yes | Catches config, plugin, and rendering errors |
| `link-check` | `mkdocs-link-check.yml` (selective `warn`) | No | Surfaces genuinely broken links |

### Why selective validation levels in link-check

Not all link warnings indicate real problems:

- **`not_found`** → `warn`: genuinely missing files or nav entries — these are real broken links
- **`anchors`** → `warn`: anchors that don't exist on the target page — genuinely broken
- **`absolute_links`** → `info`: links like `/latest/getting-started` work correctly on the live site but MkDocs can't verify them at build time since it doesn't know the runtime URL structure. These are false positives, not broken links.
- **`unrecognized_links`** → `info`: edge cases like a `LICENSE` link in a README that resolves on GitHub but not in MkDocs. Not actionable.

This gives us **17 real warnings** (missing files + broken anchors) instead of 33 with noise from working absolute links.

## Test plan

- [ ] `build` job passes (link warnings at info, non-fatal)
- [ ] `link-check` job fails with ~17 genuine broken link warnings
- [ ] `CI Required Checks` passes (only depends on `build`, not `link-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated link validation in the documentation build pipeline to identify broken links, missing navigation items, and invalid anchors before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->