### PR TITLE
docs: add prompt federation documentation for MCP Gateway

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,9 +212,10 @@ plugins:
           - /KUADRANT.md
           - /kuadrant-dev-setup/README.md
         - name: mcp-gateway
-          import_url: https://github.com/kuadrant/mcp-gateway?edit_uri=/blob/main/&branch=release-0.6.0
+          import_url: https://github.com/kuadrant/mcp-gateway?edit_uri=/blob/main/&branch=main
           imports:
           - /docs/guides/overview.md
+          - /docs/guides/README.md
           - /docs/design/overview.md
           - /docs/design/flows.md
           - /docs/design/images/mcp-gateway.jpg
@@ -223,6 +224,7 @@ plugins:
           - /docs/guides/configure-mcp-gateway-listener-and-router.md
           - /docs/guides/register-mcp-servers.md
           - /docs/guides/virtual-mcp-servers.md
+          - /docs/guides/prompt-federation.md
           - /docs/guides/external-mcp-server.md
           - /docs/guides/authentication.md
           - /docs/guides/authorization.md
@@ -360,6 +362,7 @@ nav:
           - 'MCP Servers':
               - 'MCP Server Configuration': mcp-gateway/docs/guides/register-mcp-servers.md
               - 'Virtual MCP Servers': mcp-gateway/docs/guides/virtual-mcp-servers.md
+              - 'Prompt Federation': mcp-gateway/docs/guides/prompt-federation.md
               - 'External MCP Servers': mcp-gateway/docs/guides/external-mcp-server.md
           - 'Security':
               - 'Authentication': mcp-gateway/docs/guides/authentication.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -362,7 +362,6 @@ nav:
           - 'MCP Servers':
               - 'MCP Server Configuration': mcp-gateway/docs/guides/register-mcp-servers.md
               - 'Virtual MCP Servers': mcp-gateway/docs/guides/virtual-mcp-servers.md
-              - 'Prompt Federation': mcp-gateway/docs/guides/prompt-federation.md
               - 'External MCP Servers': mcp-gateway/docs/guides/external-mcp-server.md
           - 'Security':
               - 'Authentication': mcp-gateway/docs/guides/authentication.md
@@ -372,3 +371,4 @@ nav:
               - 'Tool Revocation': mcp-gateway/docs/guides/tool-revocation.md
           - 'Support':
               - 'Troubleshooting': mcp-gateway/docs/guides/troubleshooting.md
+eway/docs/guides/troubleshooting.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,7 +212,7 @@ plugins:
           - /KUADRANT.md
           - /kuadrant-dev-setup/README.md
         - name: mcp-gateway
-          import_url: https://github.com/kuadrant/mcp-gateway?edit_uri=/blob/main/&branch=main
+          import_url: https://github.com/kuadrant/mcp-gateway?edit_uri=/blob/main/&branch=0.7.0
           imports:
           - /docs/guides/overview.md
           - /docs/guides/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,7 +212,7 @@ plugins:
           - /KUADRANT.md
           - /kuadrant-dev-setup/README.md
         - name: mcp-gateway
-          import_url: https://github.com/kuadrant/mcp-gateway?edit_uri=/blob/main/&branch=0.7.0
+          import_url: https://github.com/kuadrant/mcp-gateway?edit_uri=/blob/main/&branch=release-0.7.0
           imports:
           - /docs/guides/overview.md
           - /docs/guides/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,7 +224,6 @@ plugins:
           - /docs/guides/configure-mcp-gateway-listener-and-router.md
           - /docs/guides/register-mcp-servers.md
           - /docs/guides/virtual-mcp-servers.md
-          - /docs/guides/prompt-federation.md
           - /docs/guides/external-mcp-server.md
           - /docs/guides/authentication.md
           - /docs/guides/authorization.md
@@ -371,4 +370,3 @@ nav:
               - 'Tool Revocation': mcp-gateway/docs/guides/tool-revocation.md
           - 'Support':
               - 'Troubleshooting': mcp-gateway/docs/guides/troubleshooting.md
-eway/docs/guides/troubleshooting.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,7 +215,6 @@ plugins:
           import_url: https://github.com/kuadrant/mcp-gateway?edit_uri=/blob/main/&branch=release-0.7.0
           imports:
           - /docs/guides/overview.md
-          - /docs/guides/README.md
           - /docs/design/overview.md
           - /docs/design/flows.md
           - /docs/design/images/mcp-gateway.jpg


### PR DESCRIPTION
Add user-facing documentation for prompt federation to the MCP Gateway section.

- Updates mcp-gateway imports in mkdocs.yml to include prompt-federation.md and README.md.
- Switches mcp-gateway branch to main to pull latest changes from mcp-gateway PR #973.
- Adds "Prompt Federation" to the MCP Servers navigation.

Relates to Kuadrant/mcp-gateway#787 and Kuadrant/mcp-gateway#946