### PR TITLE
Add Console Developer Portal documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Docs will be at [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
 ```bash
 docker run \
+  --rm \
   --user $(id -u):$(id -g) \
   -v "$(pwd):/docs" \
   -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Docs will be at [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
 ```bash
 docker run \
+  --user $(id -u):$(id -g) \
   -v "$(pwd):/docs" \
   -v "$HOME/.gitconfig:/opt/app-root/src/.gitconfig:ro" \
   -v "$HOME/.ssh:/opt/app-root/src/.ssh:ro" \
@@ -98,6 +99,7 @@ To add an AsciiDoc page, create a `.adoc` file in `docs/` and add it to the `nav
    - Change each `import_url` to point at the correct release branch or tag for that component (see table above).
    - Update the `edit_uri` to match the release ref where appropriate.
 3. Update the version default in `mkdocs.yml`:
+
    ```yaml
    extra:
      version:
@@ -106,12 +108,16 @@ To add an AsciiDoc page, create a `.adoc` file in `docs/` and add it to the `nav
          - 1.4.x
          - latest
    ```
+
 4. Build and verify: `mkdocs build -s`
 5. Deploy with the `latest` alias:
+
    ```bash
    mike deploy --update-aliases 1.4.x latest --push
    ```
+
 6. Set as default:
+
    ```bash
    mike set-default 1.4.x --push
    ```

--- a/docs/backstage/apikey.md
+++ b/docs/backstage/apikey.md
@@ -1,0 +1,1 @@
+--8<-- "developer-portal-controller/docs/references/apikey.md"

--- a/docs/backstage/apikeyapproval.md
+++ b/docs/backstage/apikeyapproval.md
@@ -1,0 +1,1 @@
+--8<-- "developer-portal-controller/docs/references/apikeyapproval.md"

--- a/docs/backstage/apiproduct.md
+++ b/docs/backstage/apiproduct.md
@@ -1,0 +1,1 @@
+--8<-- "developer-portal-controller/docs/references/apiproduct.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,11 +195,14 @@ plugins:
           imports:
           - /docs/references/apiproduct.md
           - /docs/references/apikey.md
+          - /docs/references/apikeyapproval.md
         - name: kuadrant-console-plugin
           import_url: https://github.com/kuadrant/kuadrant-console-plugin?edit_uri=/blob/main/&branch=main
           imports:
           - /docs/rbac.md
           - /docs/overview.md
+          - /docs/api-management/overview.md
+          - /docs/api-management/rbac.md
         - name: kuadrant-backstage-plugin
           import_url: https://github.com/kuadrant/kuadrant-backstage-plugin?edit_uri=/blob/main/&branch=main
           imports:
@@ -359,7 +362,14 @@ nav:
       - 'Console Plugin':
           - 'Overview': kuadrant-console-plugin/docs/overview.md
           - 'RBAC': kuadrant-console-plugin/docs/rbac.md
-      - 'Developer Portal':
+          - 'Developer Portal':
+            - 'Overview': kuadrant-console-plugin/docs/api-management/overview.md
+            - 'RBAC': kuadrant-console-plugin//docs/api-management/rbac.md
+            - 'Reference':
+              - 'APIProduct': developer-portal-controller/docs/references/apiproduct.md
+              - 'APIKey': developer-portal-controller/docs/references/apikey.md
+              - 'APIKeyApproval': developer-portal-controller/docs/references/apikeyapproval.md
+      - 'Backstage Plugin':
           - 'Overview': kuadrant-backstage-plugin/docs/overview.md
           - 'Getting Started': kuadrant-backstage-plugin/docs/getting-started.md
           - 'Installation': kuadrant-backstage-plugin/docs/installation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,10 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      base_path:
+        - .
+        - temp_dir
   - attr_list
   - md_in_html
   - pymdownx.emoji:
@@ -374,8 +377,9 @@ nav:
           - 'Getting Started': kuadrant-backstage-plugin/docs/getting-started.md
           - 'Installation': kuadrant-backstage-plugin/docs/installation.md
           - 'Reference':
-              - 'APIProduct': developer-portal-controller/docs/references/apiproduct.md
-              - 'APIKey': developer-portal-controller/docs/references/apikey.md
+              - 'APIProduct': backstage/apiproduct.md
+              - 'APIKey': backstage/apikey.md
+              - 'APIKeyApproval': backstage/apikeyapproval.md
       - 'MCP Gateway':
           - 'About':
               - 'Overview': mcp-gateway/docs/guides/overview.md


### PR DESCRIPTION
## Summary
- Reorganize Console Plugin documentation to include Developer Portal docs
- Add Developer Portal overview and RBAC documentation under Console Plugin section
- Add APIKeyApproval reference documentation
- Rename "Developer Portal" top-level section to "Backstage Plugin" for clarity

## Changes
- Moved Developer Portal docs under Console Plugin as a subsection
- Added imports for Console Plugin Developer Portal docs (`/docs/api-management/overview.md`, `/docs/api-management/rbac.md`)
- Added APIKeyApproval reference import
- Updated navigation structure to nest Developer Portal under Console Plugin
- Added reference documentation links for APIProduct, APIKey, and APIKeyApproval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganised Developer Portal and Backstage navigation to surface new Overview and RBAC pages and expanded API reference entries (including APIKeyApproval).
  * Added streamlined content includes to centralise reference docs for APIProduct, APIKey and APIKeyApproval.
  * Updated docs build/run instructions to run the site container with the current user and refined snippet inclusion configuration for more reliable content embedding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->